### PR TITLE
Fix Sniper Rifles + "sf2_ignore_round_win_conditions" cvar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+.vscode/
+
 # =========================
 # Operating System Files
 # =========================

--- a/addons/sourcemod/gamedata/sf2.txt
+++ b/addons/sourcemod/gamedata/sf2.txt
@@ -19,6 +19,11 @@
 				"windows"	"327"
 				"linux"		"328"
 			}
+			"CTFWeaponBase::GetCustomDamageType"
+			{
+				"windows"	"373"
+				"linux"		"379"	
+			}
 			"CTFGameRules::IsInTraining"
 			{
 				"linux"		"182"


### PR DESCRIPTION
This adds "sf2_ignore_round_win_conditions" cvar, which suspends the round from ending by normal means; I personally find it useful for debugging things without having to deal with round restarts.

This also fixes Sniper Rifles functionality in the PvP arena. Damage no longer has to be manually applied with Sniper Rifles and the fake lag compensation feature is no longer needed so I removed it. However, this fix adds a `CTFWeaponBase::GetCustomDamageType()` vtable offset hook and a `WeaponEquipPost` hook. I used `WeaponEquipPost` instead of a `Spawn` hook/`OnEntityCreated` because I wasn't able to detect weapon creation in those functions.

This has been tested for Windows and it works but I've not tested the Linux offset, though there's a good chance it works since I pulled the offsets from VTable Dumper.