### PR TITLE
Some more PvP + typo fixes 

### DIFF
--- a/addons/sourcemod/gamedata/sf2.txt
+++ b/addons/sourcemod/gamedata/sf2.txt
@@ -34,6 +34,11 @@
 				"linux"		"136"
 				"windows"	"135"
 			}
+			"CBaseEntity::GetDamage"
+			{
+				"linux"		"129"
+				"windows"	"128"
+			}
 			"CBaseEntity::ShouldTransmit"
 			{
 				"windows"	"18"
@@ -64,6 +69,11 @@
 			{
 				"linux"		"288"
 				"windows"	"283"
+			}
+			"CBaseProjectile::CanCollideWithTeammates"
+			{
+				"linux"		"223"
+				"windows"	"222"
 			}
 			"CTFPlayer::EquipWearable"
 			{

--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -810,6 +810,7 @@ Handle g_hSDKWeaponPistol;
 Handle g_hSDKWeaponWrench;
 
 Handle g_hSDKGetMaxHealth;
+Handle g_hSDKEntityGetDamage;
 Handle g_hSDKGetLastKnownArea;
 Handle g_hSDKUpdateLastKnownArea;
 Handle g_hSDKWantsLagCompensationOnEntity;
@@ -826,6 +827,7 @@ Handle g_hSDKStartTouch;
 Handle g_hSDKEndTouch;
 Handle g_hSDKWeaponSwitch;
 Handle g_hSDKWeaponGetCustomDamageType;
+Handle g_hSDKProjectileCanCollideWithTeammates;
 
 int g_iOffset_m_id;
 
@@ -1409,6 +1411,14 @@ static void SDK_Init()
 	}*/
 
 	StartPrepSDKCall(SDKCall_Entity);
+	PrepSDKCall_SetFromConf(hConfig, SDKConf_Virtual, "CBaseEntity::GetDamage");
+	PrepSDKCall_SetReturnInfo(SDKType_Float, SDKPass_Plain);
+	if ((g_hSDKEntityGetDamage = EndPrepSDKCall()) == INVALID_HANDLE)
+	{
+		SetFailState("Failed to retrieve CBaseEntity::GetDamage offset from SF2 gamedata!");
+	}
+
+	StartPrepSDKCall(SDKCall_Entity);
 	PrepSDKCall_SetFromConf(hConfig, SDKConf_Virtual, "CBaseEntity::GetVectors");
 	PrepSDKCall_AddParameter(SDKType_Vector, SDKPass_ByRef, _, VENCODE_FLAG_COPYBACK);
 	PrepSDKCall_AddParameter(SDKType_Vector, SDKPass_ByRef, _, VENCODE_FLAG_COPYBACK);
@@ -1456,6 +1466,9 @@ static void SDK_Init()
 	
 	iOffset = GameConfGetOffset(hConfig, "CTFWeaponBase::GetCustomDamageType");
 	g_hSDKWeaponGetCustomDamageType = DHookCreate(iOffset, HookType_Entity, ReturnType_Int, ThisPointer_CBaseEntity, Hook_WeaponGetCustomDamageType);
+
+	iOffset = GameConfGetOffset(hConfig, "CBaseProjectile::CanCollideWithTeammates");
+	g_hSDKProjectileCanCollideWithTeammates = DHookCreate(iOffset, HookType_Entity, ReturnType_Bool, ThisPointer_CBaseEntity);
 
 	g_iOffset_m_id = GameConfGetOffset(hConfig, "CNavArea::m_id");
 	


### PR DESCRIPTION
Mostly PvP Arena changes, with some typo correction:

- **Fixes Soldier rockets and Pyro flares not colliding with teammates in PvP shortly after their creation.** Normally, when these entities gets first created, `CBaseProjectile::CanCollideWithTeammates()` will return false until after 0.25 seconds has passed. This is overridden to `true` when the player is in PvP.
- **Adds PvP logic to Dragon's Fury projectiles in PvP.** The projectile will normally ignore all teammates of its owner entity (the player), even if friendly fire is enabled. I considered using a signature hook to `CBaseEntity::InSameTeam()` but that proved to be too unstable and affected *a lot* of weapons (for obvious reasons), so I decided to emulate the projectile's enemy logic instead. This change does not include the fire rate bonus when hitting an enemy. This uses the `CBaseEntity::GetDamage()` function to get the damage set on the projectile as there's no accessible property on the projectile that gives this value.
- **PvP Loose Cannon projectiles/flares are removed upon hitting a player that's not in PvP.** I assumed from a comment that this was the intended result, but the logic in `PvP_OnEntityCreated` made absolutely no sense and I had to redo it especially the logic involving `g_sPvPProjectileClassesNoTouch`. The knockback in the Loose Cannon projectiles sometimes still happens.

Other minor changes include deleting spaghetti from `PvP_GetWeaponCustomDamageType` and fixing a typo in `SDK_Init`.