### PR TITLE
Fixup sf2.inc documentation and API

### DIFF
--- a/addons/sourcemod/scripting/include/sf2.inc
+++ b/addons/sourcemod/scripting/include/sf2.inc
@@ -178,78 +178,287 @@ enum SF2RoundState
 #define PROJ_BASEBALL (1 << 7)
 #define PROJ_FIREBALL_ATTACK (1 << 8)
 
-forward SF2_OnBossAdded(iBossIndex);
+/**
+ * Called when a boss is added into the game.
+ *
+ * @param iBossIndex	The index of the newly created boss.
+ */
+forward void SF2_OnBossAdded(int iBossIndex);
 
-forward SF2_OnBossSpawn(iBossIndex);
+/**
+ * Called when the boss spawns into the map.
+ *
+ * @param iBossIndex	Boss index.
+ */
+forward void SF2_OnBossSpawn(int iBossIndex);
 
-forward SF2_OnBossChangeState(iBossIndex, iOldState, iNewState);
+/**
+ * Called when the boss despawns from the map.
+ *
+ * @param iBossIndex	Boss index.
+ */
+forward void SF2_OnBossDespawn(int iBossIndex);
 
-forward Action:SF2_OnBossAnimationUpdate(iBossIndex);
+/**
+ * Called when the boss changes states. Currently only used for Chaser bosses.
+ *
+ * @param iBossIndex	Boss index.
+ * @param iOldState		The old state.
+ * @param iNewState		The new state.
+ */
+forward void SF2_OnBossChangeState(int iBossIndex, int iOldState, int iNewState);
 
-forward Action:SF2_OnBossGetSpeed(client, &Float:flSpeed);
+/**
+ * Called when the boss updates its animation.
+ *
+ * @param iBossIndex	Boss index. 
+ * @return				If Plugin_Handled, animation change will be blocked.
+ */
+forward Action SF2_OnBossAnimationUpdate(int iBossIndex);
 
-forward Action:SF2_OnBossGetWalkSpeed(client, &Float:flWalkSpeed);
+/**
+ * Called to determine the boss's run speed.
+ *
+ * @param iBossIndex	Boss index.
+ * @param flSpeed		The boss's run speed.
+ * @return				If Plugin_Changed, flSpeed is used as the boss's run speed.
+ */
+forward Action SF2_OnBossGetSpeed(int iBossIndex, float &flSpeed);
 
-forward SF2_OnBossRemoved(iBossIndex);
+/**
+ * Called to determine the boss's walk speed.
+ *
+ * @param iBossIndex	Boss index.
+ * @param flSpeed		The boss's walk speed.
+ * @return				If Plugin_Changed, flSpeed is used as the boss's walk speed.
+ */
+forward Action SF2_OnBossGetWalkSpeed(int iBossIndex, float &flWalkSpeed);
 
-forward SF2_OnPagesSpawned();
+/**
+ * Called after the boss has determined it can hear the entity.
+ *
+ * @param iBossIndex	Boss index.
+ * @param entity		Entity index.
+ * @return				Returning a value other than Plugin_Continue will block hearing to the entity.
+ */
+forward Action SF2_OnBossHearEntity(int iBossIndex, int entity);
 
-forward SF2_OnClientCollectPage(pageEnt, client);
+/**
+ * Called after the boss has determined it can see the entity.
+ *
+ * @param iBossIndex	Boss index.
+ * @param entity		Entity index.
+ * @return				Returning a value other than Plugin_Continue will block vision to the entity.
+ */
+forward Action SF2_OnBossSeeEntity(int iBossIndex, int entity);
 
-forward SF2_OnClientBlinked(client);
+/**
+ * Called when a boss is removed from the game.
+ *
+ * @param iBossIndex	The index of the boss to be removed.
+ */
+forward void SF2_OnBossRemoved(int iBossIndex);
 
-forward SF2_OnClientCaughtByBoss(client, iBossIndex);
+/**
+ * Called when pages have spawned into the map.
+ */
+forward void SF2_OnPagesSpawned();
 
-forward Action:SF2_OnClientGiveQueuePoints(client, &iAddAmount);
+/**
+ * Called when the round state changes.
+ * 
+ * @param iOldState		Old state.
+ * @param iNewState		New state.
+ */
+forward void SF2_OnRoundStateChange(SF2RoundState iOldState, SF2RoundState iNewState);
 
-forward SF2_OnClientActivateFlashlight(client);
+/**
+ * Called when a player collects a page.
+ *
+ * @param pageEnt	The entity index of the page.
+ * @param client	Client index.
+ */
+forward void SF2_OnClientCollectPage(int pageEnt, int client);
 
-forward SF2_OnClientDeactivateFlashlight(client);
+/**
+ * Called when a player blinks.
+ *
+ * @param client	Client index.
+ */
+forward void SF2_OnClientBlink(int client);
 
-forward SF2_OnClientBreakFlashlight(client);
+/**
+ * Called when the player gets caught by a boss, either from too much static, being within
+ * a boss's kill radius, or dies from too much camping. This is also called for fake bosses.
+ *
+ * @param client		Client index.
+ * @param iBossIndex	Boss index.
+ */
+forward void SF2_OnClientCaughtByBoss(int client, int iBossIndex);
 
-forward SF2_OnClientEscape(client);
+/**
+ * Called when giving queue points to the player at the end of the round.
+ *
+ * @param client		Client index.
+ * @param iAddAmount	The amount of queue points to give.
+ * @return				If Plugin_Changed, iAddAmount will be used as the amount to give.
+ */
+forward Action SF2_OnClientGiveQueuePoints(int client, int &iAddAmount);
 
-forward SF2_OnClientLooksAtBoss(client, iBossIndex);
+/**
+ * Called when the player turns on their flashlight.
+ *
+ * @param client		Client index.
+ */
+forward void SF2_OnClientActivateFlashlight(int client);
 
-forward SF2_OnClientLooksAwayFromBoss(client, iBossIndex);
+/**
+ * Called when the player turns off their flashlight.
+ *
+ * @param client		Client index.
+ */
+forward void SF2_OnClientDeactivateFlashlight(int client);
 
-forward SF2_OnClientStartDeathCam(client, iBossIndex);
+/**
+ * Called when the player breaks their flashlight.
+ *
+ * @param client		Client index.
+ */
+forward void SF2_OnClientBreakFlashlight(int client);
 
-forward SF2_OnClientEndDeathCam(client, iBossIndex);
+/**
+ * Called when the player starts sprinting.
+ *
+ * @param client		Client index.
+ */
+forward void SF2_OnClientStartSprinting(int client);
 
-forward Action:SF2_OnClientGetDefaultWalkSpeed(client, &Float:flDefault);
+/**
+ * Called when the player stops sprinting.
+ *
+ * @param client		Client index.
+ */
+forward void SF2_OnClientStopSprinting(int client);
 
-forward Action:SF2_OnClientGetDefaultSprintSpeed(client, &Float:flDefault);
+/**
+ * Called when the player escapes from the map.
+ *
+ * @param client		Client index.
+ */
+forward void SF2_OnClientEscape(int client);
 
-forward Action:SF2_OnClientTakeDamage(victim, attacker, &Float:damage);
+/**
+ * Called when the player looks at the boss.
+ *
+ * @param client		Client index.
+ * @param iBossIndex	Boss the client is looking at.
+ */
+forward void SF2_OnClientLooksAtBoss(int client, int iBossIndex);
 
-forward Action:SF2_OnGroupGiveQueuePoints(iGroupIndex, &iAddAmount);
+/**
+ * Called when the player looks away from the boss.
+ *
+ * @param client		Client index.
+ * @param iBossIndex	Boss the client is no longer looking at.
+ */
+forward void SF2_OnClientLooksAwayFromBoss(int client, int iBossIndex);
 
-forward SF2_OnClientDamagedByBoss(client, iBossIndex, inflictor, Float:flDamage, iDamageType);
+/**
+ * Called when the player gets caught in a boss's deathcam.
+ *
+ * @param client		Client index.
+ * @param iBossIndex	Boss index.
+ */
+forward void SF2_OnClientStartDeathCam(int client, int iBossIndex);
 
-forward SF2_OnClientSpawnedAsProxy(client);
+/**
+ * Called when the player gets exits a boss's deathcam.
+ *
+ * @param client		Client index.
+ * @param iBossIndex	Boss index.
+ */
+forward void SF2_OnClientEndDeathCam(int client, int iBossIndex);
+
+/**
+ * Called to determine a player's default walk speed.
+ *
+ * @param client		Client index.
+ * @param flDefault		The default walk speed.
+ * @return				If Plugin_Changed, flDefault is used as player's default walk speed.
+ */
+forward Action SF2_OnClientGetDefaultWalkSpeed(int client, float &flDefault);
+
+/**
+ * Called to determine a player's default sprint speed.
+ *
+ * @param client		Client index.
+ * @param flDefault		The default sprint speed.
+ * @return				If Plugin_Changed, flDefault is used as player's default sprint speed.
+ */
+forward Action SF2_OnClientGetDefaultSprintSpeed(int client, float &flDefault);
+
+/**
+ * Called when a player gets damaged.
+ *
+ * @param victim		The player who got damaged.
+ * @param attacker		The damage source.
+ * @param damage		The amount of damage to take.
+ * @return				If Plugin_Changed, damage is overrided.
+ */
+forward Action SF2_OnClientTakeDamage(int victim, int attacker, float &damage);
+
+/**
+ * Called when giving queue points to the group at the end of the round.
+ *
+ * @param iGroupIndex		Group index.
+ * @param iAddAmount		The amount of queue points to give.
+ * @return					If Plugin_Changed, iAddAmount will be used as the amount to give.
+ */
+forward Action SF2_OnGroupGiveQueuePoints(int iGroupIndex, int &iAddAmount);
+
+/**
+ * Called when a player gets damaged by the boss.
+ *
+ * @param client		The player who got damaged.
+ * @param iBossIndex	Boss that damaged the player.
+ * @param inflictor		The inflictor of the damage.
+ * @param flDamage		The amount of damage taken.
+ * @param iDamageType	The damage type.
+ */
+forward void SF2_OnClientDamagedByBoss(int client, int iBossIndex, int inflictor, float flDamage, int iDamageType);
+
+/**
+ * Called when a player spawns as a proxy.
+ */
+forward void SF2_OnClientSpawnedAsProxy(int client);
 
 /**
  * Returns a bool about the gamemode's state.
  *
  * @return				True if the gamemode is running, false if not.
  */
-native bool:SF2_IsRunning();
+native bool SF2_IsRunning();
 
 /**
  * Returns the current state of the round.
  *
- * @return				Current state or the round.
+ * @return				Current state of the round.
  */
-native SF2_GetRoundState();
+native SF2RoundState SF2_GetRoundState();
+
+/**
+ * Returns whether or not the round is in grace period.
+ *
+ * @return				True if in grace period, false otherise.
+ */
+native bool SF2_IsRoundInGracePeriod();
 
 /**
  * Returns the current difficulty of the round.
  *
  * @return				Integer of the difficulty.
  */
-native SF2_GetCurrentDifficulty();
+native int SF2_GetCurrentDifficulty();
 
 /**
  * Returns the current difficulty of the round.
@@ -257,21 +466,21 @@ native SF2_GetCurrentDifficulty();
  * @param iDifficulty	Difficulty number.
  * @return				Modifier float value of the indicated difficulty number.
  */
-native Float:SF2_GetDifficultyModifier(iDifficulty);
+native float SF2_GetDifficultyModifier(int iDifficulty);
 
 /**
  * Returns a bool indicating whether or not a special round is currently running.
  *
  * @return				True if a special round is running, false if not.
  */
-native bool:SF2_IsSpecialRoundRunning();
+native bool SF2_IsSpecialRoundRunning();
 
 /**
  * Returns the type of special round that is running.
  *
  * @return				Special round type.
  */
-native SF2_GetSpecialRoundType();
+native int SF2_GetSpecialRoundType();
 
 /**
  * Returns a bool about the client's elimination state.
@@ -279,7 +488,7 @@ native SF2_GetSpecialRoundType();
  * @param client		Client index.
  * @return				True if the player is eliminated, false if not.
  */
-native bool:SF2_IsClientEliminated(client);
+native bool SF2_IsClientEliminated(int client);
 
 /**
  * Returns a bool about the client's ghost mode state.
@@ -287,7 +496,7 @@ native bool:SF2_IsClientEliminated(client);
  * @param client		Client index.
  * @return				True if the player is in Ghost Mode, false if not.
  */
-native bool:SF2_IsClientInGhostMode(client);
+native bool SF2_IsClientInGhostMode(int client);
 
 /**
  * Returns a bool if the client is in a Player vs. Player zone or not.
@@ -295,7 +504,7 @@ native bool:SF2_IsClientInGhostMode(client);
  * @param client		Client index.
  * @return				True if the player is in a PvP zone, false if not.
  */
-native bool:SF2_IsClientInPvP(client);
+native bool SF2_IsClientInPvP(int client);
 
 /**
  * Tells whether if the client is a Proxy or not.
@@ -303,7 +512,7 @@ native bool:SF2_IsClientInPvP(client);
  * @param client		Client index.
  * @return				True if the player is a Proxy, false if not.
  */
-native bool:SF2_IsClientProxy(client);
+native bool SF2_IsClientProxy(int client);
 
 /**
  * Tells whether or not the client is looking at the boss.
@@ -312,7 +521,7 @@ native bool:SF2_IsClientProxy(client);
  * @param iBossIndex	Boss index.
  * @return				True if the player is a Proxy, false if not.
  */
-native bool:SF2_IsClientLookingAtBoss(client, iBossIndex);
+native bool SF2_IsClientLookingAtBoss(int client, int iBossIndex);
 
 /**
  * Gives the amount of times the client has blinked in one life. This count will reset upon spawn.
@@ -320,7 +529,29 @@ native bool:SF2_IsClientLookingAtBoss(client, iBossIndex);
  * @param client		Client index.
  * @return				Number of times the client has blinked in one life.
  */
-native SF2_GetClientBlinkCount(client);
+native int SF2_GetClientBlinkCount(int client);
+
+/**
+ * Returns whether or not the client is in a blink state (visibility obscured).
+ *
+ * @param client		Client index.
+ * @return				True if blinking, false otherwise.
+ */
+native bool SF2_IsClientBlinking(int client);
+
+/**
+ * Returns the value of the client's blink meter.
+ * @param client		Client index.
+ * @return				Blink meter, a value between 0 and 1.
+ */
+native float SF2_GetClientBlinkMeter(int client);
+
+/**
+ * Sets the value of the client's blink meter.
+ * @param client		Client index.
+ * @param amount		Blink meter, a value between 0 and 1.
+ */
+native void SF2_SetClientBlinkMeter(int client, float amount);
 
 /**
  * If the client is a Proxy, then this returns the boss index that the client is associated with.
@@ -328,7 +559,15 @@ native SF2_GetClientBlinkCount(client);
  * @param client		Client index.
  * @return				If the client is a proxy, then this will return a boss index, -1 if not.
  */
-native SF2_GetClientProxyMaster(client);
+native int SF2_GetClientProxyMaster(int client);
+
+/**
+ * If the client is a Proxy, then this sets the boss index that the client is associated with.
+ *
+ * @param client		Client index.
+ * @param iBossIndex	Boss index.
+ */
+native void SF2_SetClientProxyMaster(int client, int iBossIndex);
 
 /**
  * If the client is a Proxy, then this returns the amount of Control points the client has left.
@@ -336,65 +575,554 @@ native SF2_GetClientProxyMaster(client);
  * @param client		Client index.
  * @return				If the client is a proxy, then this will return the amount of Control Points out of 100, else 0.
  */
-native SF2_GetClientProxyControlAmount(client);
+native int SF2_GetClientProxyControlAmount(int client);
 
 /**
- * If the client is a Proxy, then this returns the rate which each Control point will drain for the client.
+ * If the client is a Proxy, then this sets the amount of Control points the client has left.
+ *
+ * @param client		Client index.
+ * @param iAmount		The amount of Control points. Must be between 0-100.
+ */
+native void SF2_SetClientProxyControlAmount(int client, int iAmount);
+
+/**
+ * If the client is a Proxy, then this returns the interval which each Control point will drain for the client.
  *
  * @param client		Client index.
  * @return				If the client is a proxy, then this will return a boss index, -1 if not.
  */
-native Float:SF2_GetClientProxyControlRate(client);
+native float SF2_GetClientProxyControlRate(int client);
 
-native bool:SF2_DidClientEscape(client);
+/**
+ * If the client is a Proxy, then this sets the interval which each Control point will drain for the client.
+ *
+ * @param client		Client index.
+ * @param flInterval	Interval to subtract one Control point from the client.
+ */
+native float SF2_SetClientProxyControlRate(int client, float flInterval);
 
-native SF2_SetClientProxyMaster(client, iBossIndex);
+/**
+ * Tells whether or not the client escaped from the map.
+ *
+ * @param client		Client index.
+ * @return				True if the client escaped, false otherwise.
+ */
+native bool SF2_DidClientEscape(int client);
 
-native SF2_SetClientProxyControlAmount(client, iAmount);
+/**
+ * Forces a client to escape.
+ *
+ * @param client		Client index.
+ */
+native void SF2_ForceClientEscape(int client);
 
-native SF2_SetClientProxyControlRate(client, Float:flAmount);
+/**
+ * Returns the amount of flashlight the client has.
+ *
+ * @param client		Client index.
+ * @return				Percentage of battery life.
+ */
+native float SF2_GetClientFlashlightBatteryLife(int client);
 
-native SF2_CollectAsPage(pageEnt, client);
+/**
+ * Sets the amount of flashlight the client has. The value should be between 0 and 1.
+ *
+ * @param client		Client index.
+ * @param batteryLife	The amount of battery life.
+ */
+native void SF2_SetClientFlashlightBatteryLife(int client, float batteryLife);
 
-native SF2_GetMaxBossCount();
+/**
+ * Returns whether or not the player is using their flashlight.
+ *
+ * @param client		Client index.
+ * @return				True if using flashlight, false otherwise.
+ */
+native bool SF2_IsClientUsingFlashlight(int client);
 
-native SF2_EntIndexToBossIndex(iEntIndex);
+/**
+ * Returns the amount of sprint points the client has.
+ *
+ * @param client	Client index.
+ * @return			Sprint points.
+ */
+native int SF2_GetClientSprintPoints(int client);
 
-native SF2_BossIndexToEntIndex(iBossIndex);
+/**
+ * Sets the amount of sprint points the client has. The value should be between 0 and 100.
+ *
+ * @param client			Client index.
+ * @param sprintPoints		Sprint points.
+ */
+native int SF2_SetClientSprintPoints(int client, int sprintPoints);
 
-native SF2_BossIndexToEntIndexEx(iBossIndex); //Don't use this function unless you know what it does!!!! Most will not!
+/**
+ * Returns whether or not the client wants to sprint.
+ *
+ * @param client			Client index.
+ * @return					True if wants to sprint, false otherwise.
+ */
+native bool SF2_IsClientSprinting(int client);
 
-native SF2_BossIDToBossIndex(iBossID);
+/**
+ * Returns whether or not the client is actually in sprint state.
+ *
+ * @param client			Client index.
+ * @return					True if in sprint state, false otherwise.
+ */
+native bool SF2_IsClientReallySprinting(int client);
 
-native SF2_BossIndexToBossID(iBossID);
+/**
+ * Returns whether or not the client is caught in a trap.
+ *
+ * @param client			Client index.
+ * @return					True if trapped, false otherwise.
+ */
+native bool SF2_IsClientTrapped(int client);
 
-native SF2_GetBossName(iBossIndex, String:sBuffer[], iBufferLen);
+/**
+ * Collects the given entity as a page.
+ *
+ * @param pageEnt		Entity index.
+ * @param client		Client index.
+ */
+native void SF2_CollectAsPage(int pageEnt, int client);
 
-native SF2_GetBossModelEntity(iBossIndex);
+/**
+ * Returns the maximum boss count.
+ *
+ * @return	Maximum boss count.
+ */
+native int SF2_GetMaxBossCount();
 
-native SF2_GetBossTarget(iBossIndex);
+/**
+ * Converts the entity index into a boss index.
+ *
+ * @param iEntIndex		Entity index.
+ * @return				Boss index, or -1 if entity index is not a boss.
+ */
+native int SF2_EntIndexToBossIndex(int iEntIndex);
 
-native SF2_GetBossMaster(iBossIndex);
+/**
+ * Returns the entity index of a boss.
+ *
+ * @param iBossIndex	Boss index.
+ * @return				Entity index, or -1 if the boss has not spawned.
+ */
+native int SF2_BossIndexToEntIndex(int iBossIndex);
 
-native SF2_GetBossState(iBossIndex);
+native int SF2_BossIndexToEntIndexEx(int iBossIndex); //Don't use this function unless you know what it does!!!! Most will not!
 
-native Float:SF2_GetBossFOV(iBossIndex);
+/**
+ * Converts a boss unique ID to a boss index.
+ *
+ * @param iBossID		Unique id.
+ * @return				Boss index, or -1 if no boss has the unique id.
+ */
+native int SF2_BossIDToBossIndex(int iBossID);
 
-native bool:SF2_IsBossProfileValid(const String:sProfile[]);
+/**
+ * Returns the unique ID of a boss. A unique ID to a boss index is the equivalent of an entity reference to an entity index.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					Unique id.
+ */
+native int SF2_BossIndexToBossID(int iBossIndex);
 
-native SF2_GetBossProfileNum(const String:sProfile[], const String:sKey[], iDefaultValue=0);
+/**
+ * Adds a boss into the game.
+ *
+ * @param profile			Name of profile.
+ * @param flags				Additional flags to add to the boss.
+ * @param spawnCompanions	Add companions of the boss.
+ * @param playSpawnSound	Play spawn sound.
+ * @return					Boss index, or -1 if failed.
+ */
+native int SF2_AddBoss(const char[] profile, int flags=0, bool spawnCompanions=true, bool playSpawnSound=true);
 
-native Float:SF2_GetBossProfileFloat(const String:sProfile[], const String:sKey[], Float:flDefaultValue=0.0);
+/**
+ * Removes a boss from the game.
+ *
+ * @param iBossIndex	Boss index.
+ */
+native void SF2_RemoveBoss(int iBossIndex);
 
-native bool:SF2_GetBossProfileString(const String:sProfile[], const String:sKey[], String:sBuffer[], iBufferLen, const String:sDefaultValue[]="");
+/**
+ * Retrieves the profile name of the boss.
+ *
+ * @param iBossIndex		Boss index.
+ * @param sBuffer			Buffer to store the profile name.
+ * @param iBufferLen		Max length of sBuffer.
+ */
+native void SF2_GetBossName(int iBossIndex, char[] sBuffer, int iBufferLen);
 
-native bool:SF2_GetBossProfileVector(const String:sProfile[], const String:sKey[], Float:flBuffer[3], const Float:flDefaultValue[3]=NULL_VECTOR);
+/**
+ * Returns the type of the boss. See the SF2BossType enumeration for possible values.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					Entity index.
+ */
+native int SF2_GetBossType(int iBossIndex);
 
-native bool:SF2_GetRandomStringFromBossProfile(const String:sProfile, const String:sKey[], String:sBuffer[], iBufferLen, iIndex=-1);
+/**
+ * Returns the flags of the boss.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					Flags.
+ */
+native int SF2_GetBossFlags(int iBossIndex);
 
-native bool:SF2_IsSurvivalMap();
+/**
+ * Sets the flags of the boss.
+ *
+ * @param iBossIndex		Boss index.
+ * @param flags				Flags.
+ */
+native void SF2_SetBossFlags(int iBossIndex, int flags);
 
-public SharedPlugin:__pl_sf2 = 
+/**
+ * Spawns the boss into the map.
+ *
+ * @param iBossIndex		Boss index.
+ */
+native void SF2_SpawnBoss(int iBossIndex, const float position[3]);
+
+/**
+ * Despawns the boss from the map.
+ *
+ * @param iBossIndex		Boss index.
+ */
+native void SF2_DespawnBoss(int iBossIndex);
+
+/**
+ * Returns the entity index of the boss's model.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					Entity index.
+ */
+native int SF2_GetBossModelEntity(int iBossIndex);
+
+/**
+ * Returns the boss's current target.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					Entity index.
+ */
+native int SF2_GetBossTarget(int iBossIndex);
+
+/**
+ * If the boss is a copy, this returns the boss that this copy is associated with.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					Boss index of master boss.
+ */
+native int SF2_GetBossMaster(int iBossIndex);
+
+/**
+ * Returns the boss's current state.
+ *
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					The boss's state.
+ */
+native int SF2_GetBossState(int iBossIndex);
+
+/**
+ * Returns the boss's field of view.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					Field of view.
+ */
+native float SF2_GetBossFOV(int iBossIndex);
+
+/**
+ * If the boss is in a chase state, returns the time which the boss's persistency on the target ends.
+ * 
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					Time where persistency ends.
+ */
+native float SF2_GetBossTimeUntilNoPersistence(int iBossIndex);
+
+/**
+ * If the boss is in a chase state, sets the time which the boss's persistency on the target ends.
+ * 
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @param time				Time where persistency ends.
+ */
+native void SF2_SetBossTimeUntilNoPersistence(int iBossIndex, float time);
+
+/**
+ * If the boss is in an alert state, returns the time which the boss should revert to idle state.
+ * 
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					Time where chase state should revert to idle state.
+ */
+native float SF2_GetBossTimeUntilIdle(int iBossIndex);
+
+/**
+ * If the boss is in an alert state, sets the time which the boss should revert to idle state.
+ * 
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @param time				Time where chase state should revert to idle state.
+ */
+native void SF2_SetBossTimeUntilIdle(int iBossIndex, float time);
+
+/**
+ * If the boss is in a chase state, returns the time which the boss should revert to alert state.
+ * 
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					Time where chase state should revert to alert state.
+ */
+native float SF2_GetBossTimeUntilAlert(int iBossIndex);
+
+/**
+ * If the boss is in a chase state, sets the time which the boss should revert to alert state.
+ * 
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @param time				Time where chase state should revert to alert state.
+ */
+native void SF2_SetBossTimeUntilAlert(int iBossIndex, float time);
+
+/**
+ * Returns whether or not the boss is stunnable.
+ *
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					True if stunnable, false otherwise.
+ */
+native bool SF2_IsBossStunnable(int iBossIndex);
+
+/**
+ * Returns whether or not the boss is stunnable by flashlight.
+ *
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					True if stunnable by flashlight, false otherwise.
+ */
+native bool SF2_IsBossStunnableByFlashlight(int iBossIndex);
+
+/**
+ * Returns whether or not the boss is cloaked.
+ *
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					True if cloaked, false otherwise.
+ */
+native bool SF2_IsBossCloaked(int iBossIndex);
+
+/**
+ * Returns the amount of health the boss has before stun.
+ *
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					The health amount.
+ */
+native float SF2_GetBossStunHealth(int iBossIndex);
+
+/**
+ * Sets the amount of health the boss has before stun.
+ *
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @param health			The health amount.
+ */
+native void SF2_SetBossStunHealth(int iBossIndex, float health);
+
+/**
+ * Returns the time where the boss is not under stun cooldown.
+ * 
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @return					Time when boss is not under stun cooldown.
+ */
+native float SF2_GetBossNextStunTime(int iBossIndex);
+
+/**
+ * Sets the time where the boss is not under stun cooldown.
+ * 
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @param time				Time when boss is not under stun cooldown.
+ */
+native float SF2_SetBossNextStunTime(int iBossIndex, float time);
+
+/**
+ * Forces the boss to stop chasing.
+ *
+ * Only used with Chaser bosses.
+ *
+ * Note: If the boss is set to chase endlessly then this will not do anything.
+ *
+ * @param iBossIndex		Boss index.
+ */
+native void SF2_ForceBossGiveUp(int iBossIndex);
+
+/**
+ * Gets the current goal position of the boss.
+ *
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @param position			Buffer to store position.
+ */
+native void SF2_GetBossGoalPosition(int iBossIndex, float position[3]);
+
+/**
+ * Returns whether or not the boss is able to hear the player given sound type.
+ *
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @param client			Client index.
+ * @param soundType			The type of sound to check.
+ * @return					True if boss can hear, false otherwise.
+ */
+native bool SF2_CanBossHearClient(int iBossIndex, int client, SoundType soundType);
+
+/**
+ * Creates a sound hint for the boss to follow.
+ *
+ * Only used with Chaser bosses.
+ *
+ * @param iBossIndex		Boss index.
+ * @param soundType			The type of sound hint to create.
+ * @param position			The position of the sound.
+ */
+native void SF2_CreateBossSoundHint(int iBossIndex, SoundType soundType, const float position[3]);
+
+/**
+ * Returns if the given profile is loaded or not.
+ *
+ * @param sProfile		Profile name.
+ * @return				True if loaded, false otherwise.
+ */
+native bool SF2_IsBossProfileValid(const char[] sProfile);
+
+/**
+ * Retrieves an integer keyvalue from the profile.
+ *
+ * @param sProfile			Profile name.
+ * @param sKey				Name of the key.
+ * @param iDefaultValue		Fallback value.
+ * @return					The value, or iDefaultValue if the key doesn't exist.
+ */
+native int SF2_GetBossProfileNum(const char[] sProfile, const char[] sKey, int iDefaultValue=0);
+
+/**
+ * Retrieves a float keyvalue from the profile.
+ *
+ * @param sProfile			Profile name.
+ * @param sKey				Name of the key.
+ * @param flDefaultValue	Fallback value.
+ * @return					The value, or flDefaultValue if the key doesn't exist.
+ */
+native float SF2_GetBossProfileFloat(const char[] sProfile, const char[] sKey, float flDefaultValue=0.0);
+
+/**
+ * Retrieves a string keyvalue from the profile.
+ *
+ * @param sProfile			Profile name.
+ * @param sKey				Name of the key.
+ * @param sBuffer			Buffer to store the value.
+ * @param iBufferLen		Max length of sBuffer.
+ * @param sDefaultValue		Fallback value.
+ * @return					True if key exists; false otherwise. If false, sBuffer is set to sDefaultValue.
+ */
+native bool SF2_GetBossProfileString(const char[] sProfile, const char[] sKey, char[] sBuffer, int iBufferLen, const char[] sDefaultValue="");
+
+/**
+ * Retrieves a vector keyvalue from the profile.
+ *
+ * @param sProfile			Profile name.
+ * @param sKey				Name of the key.
+ * @param flBuffer			Buffer to store the value.
+ * @param flDefaultValue	Fallback value.
+ * @return					True if key exists; false otherwise. If false, sBuffer is set to sDefaultValue.
+ */
+native bool SF2_GetBossProfileVector(const char[] sProfile, const char[] sKey, float flBuffer[3], const float flDefaultValue[3]=NULL_VECTOR);
+
+/**
+ * Retrieves a random string keyvalue from a section within the profile.
+ *
+ * Example: In a profile, a valid section would look like this:
+ *
+ * "profile"
+ * {
+ *   "section"
+ *   {
+ *     "1"   "item1"
+ *     "2"   "item2"
+ *   }
+ * }
+ *
+ * This function will randomly choose a string value within "section" if sKey = "section".
+ * 
+ * @param sProfile			Profile name.
+ * @param sKey				Name of the key. Must be a section.
+ * @param sBuffer			Buffer to store the value.
+ * @param iBufferLen		Max length of sBuffer.
+ * @param iIndex			If < 0, value will be chosen randomly; otherwise will retrieve the value with the specified index.
+ * @return					True if profile exists and key is set; false otherwise.
+ */
+native bool SF2_GetRandomStringFromBossProfile(const char[] sProfile, const char[] sKey, char[] sBuffer, int iBufferLen, int iIndex=-1);
+
+/**
+ * Returns if current map is a survival map or not.
+ *
+ * @return	True if current map is a survival map; false otherwise.
+ */
+native bool SF2_IsSurvivalMap();
+
+/**
+ * Returns if current map is a Boxing map or not.
+ *
+ * @return	True if Boxing map, false otherwise.
+ */
+native bool SF2_IsBoxingMap();
+
+/**
+ * Returns if current map is a Raid map or not.
+ *
+ * @return	True if Raid map, false otherwise.
+ */
+native bool SF2_IsRaidMap();
+
+/**
+ * Returns if current map is a Proxy map or not.
+ *
+ * @return	True if Proxy map, false otherwise.
+ */
+native bool SF2_IsProxyMap();
+
+/**
+ * Returns if current map is a Renevant map or not.
+ *
+ * @return	True if Renevant map, false otherwise.
+ */
+native bool SF2_IsRenevantMap();
+
+
+public SharedPlugin __pl_sf2 = 
 {
 	name = "sf2",
 	file = "sf2.smx",

--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -749,12 +749,16 @@ int g_LightningSprite;
 // Global forwards.
 Handle fOnBossAdded;
 Handle fOnBossSpawn;
+Handle fOnBossDespawn;
 Handle fOnBossChangeState;
 Handle fOnBossAnimationUpdate;
 Handle fOnBossGetSpeed;
 Handle fOnBossGetWalkSpeed;
+Handle fOnBossSeeEntity;
+Handle fOnBossHearEntity;
 Handle fOnBossRemoved;
 Handle fOnPagesSpawned;
+Handle fOnRoundStateChange;
 Handle fOnClientCollectPage;
 Handle fOnClientBlink;
 Handle fOnClientCaughtByBoss;
@@ -762,6 +766,8 @@ Handle fOnClientGiveQueuePoints;
 Handle fOnClientActivateFlashlight;
 Handle fOnClientDeactivateFlashlight;
 Handle fOnClientBreakFlashlight;
+Handle fOnClientStartSprinting;
+Handle fOnClientStopSprinting;
 Handle fOnClientEscape;
 Handle fOnClientLooksAtBoss;
 Handle fOnClientLooksAwayFromBoss;
@@ -865,12 +871,16 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error,int err_max)
 	
 	fOnBossAdded = CreateGlobalForward("SF2_OnBossAdded", ET_Ignore, Param_Cell);
 	fOnBossSpawn = CreateGlobalForward("SF2_OnBossSpawn", ET_Ignore, Param_Cell);
+	fOnBossDespawn = CreateGlobalForward("SF2_OnBossDespawn", ET_Ignore, Param_Cell);
 	fOnBossChangeState = CreateGlobalForward("SF2_OnBossChangeState", ET_Ignore, Param_Cell, Param_Cell, Param_Cell);
 	fOnBossAnimationUpdate = CreateGlobalForward("SF2_OnBossAnimationUpdate", ET_Hook, Param_Cell);
 	fOnBossGetSpeed = CreateGlobalForward("SF2_OnBossGetSpeed", ET_Hook, Param_Cell, Param_FloatByRef);
 	fOnBossGetWalkSpeed = CreateGlobalForward("SF2_OnBossGetWalkSpeed", ET_Hook, Param_Cell, Param_FloatByRef);
+	fOnBossHearEntity = CreateGlobalForward("SF2_OnBossHearEntity", ET_Hook, Param_Cell, Param_Cell);
+	fOnBossSeeEntity = CreateGlobalForward("SF2_OnBossSeeEntity", ET_Hook, Param_Cell, Param_Cell);
 	fOnBossRemoved = CreateGlobalForward("SF2_OnBossRemoved", ET_Ignore, Param_Cell);
 	fOnPagesSpawned = CreateGlobalForward("SF2_OnPagesSpawned", ET_Ignore);
+	fOnRoundStateChange = CreateGlobalForward("SF2_OnRoundStateChange", ET_Ignore, Param_Cell, Param_Cell);
 	fOnClientCollectPage = CreateGlobalForward("SF2_OnClientCollectPage", ET_Ignore, Param_Cell, Param_Cell);
 	fOnClientBlink = CreateGlobalForward("SF2_OnClientBlink", ET_Ignore, Param_Cell);
 	fOnClientCaughtByBoss = CreateGlobalForward("SF2_OnClientCaughtByBoss", ET_Ignore, Param_Cell, Param_Cell);
@@ -878,6 +888,8 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error,int err_max)
 	fOnClientActivateFlashlight = CreateGlobalForward("SF2_OnClientActivateFlashlight", ET_Ignore, Param_Cell);
 	fOnClientDeactivateFlashlight = CreateGlobalForward("SF2_OnClientDeactivateFlashlight", ET_Ignore, Param_Cell);
 	fOnClientBreakFlashlight = CreateGlobalForward("SF2_OnClientBreakFlashlight", ET_Ignore, Param_Cell);
+	fOnClientStartSprinting = CreateGlobalForward("SF2_OnClientStartSprinting", ET_Ignore, Param_Cell);
+	fOnClientStopSprinting = CreateGlobalForward("SF2_OnClientStopSprinting", ET_Ignore, Param_Cell);
 	fOnClientEscape = CreateGlobalForward("SF2_OnClientEscape", ET_Ignore, Param_Cell);
 	fOnClientLooksAtBoss = CreateGlobalForward("SF2_OnClientLooksAtBoss", ET_Ignore, Param_Cell, Param_Cell);
 	fOnClientLooksAwayFromBoss = CreateGlobalForward("SF2_OnClientLooksAwayFromBoss", ET_Ignore, Param_Cell, Param_Cell);
@@ -892,12 +904,16 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error,int err_max)
 	
 	CreateNative("SF2_IsRunning", Native_IsRunning);
 	CreateNative("SF2_GetRoundState", Native_GetRoundState);
+	CreateNative("SF2_IsRoundInGracePeriod", Native_IsRoundInGracePeriod);
 	CreateNative("SF2_GetCurrentDifficulty", Native_GetCurrentDifficulty);
 	CreateNative("SF2_GetDifficultyModifier", Native_GetDifficultyModifier);
 	CreateNative("SF2_IsClientEliminated", Native_IsClientEliminated);
 	CreateNative("SF2_IsClientInGhostMode", Native_IsClientInGhostMode);
 	CreateNative("SF2_IsClientProxy", Native_IsClientProxy);
 	CreateNative("SF2_GetClientBlinkCount", Native_GetClientBlinkCount);
+	CreateNative("SF2_IsClientBlinking", Native_IsClientBlinking);
+	CreateNative("SF2_GetClientBlinkMeter", Native_GetClientBlinkMeter);
+	CreateNative("SF2_SetClientBlinkMeter", Native_SetClientBlinkMeter);
 	CreateNative("SF2_GetClientProxyMaster", Native_GetClientProxyMaster);
 	CreateNative("SF2_GetClientProxyControlAmount", Native_GetClientProxyControlAmount);
 	CreateNative("SF2_GetClientProxyControlRate", Native_GetClientProxyControlRate);
@@ -906,6 +922,15 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error,int err_max)
 	CreateNative("SF2_SetClientProxyControlRate", Native_SetClientProxyControlRate);
 	CreateNative("SF2_IsClientLookingAtBoss", Native_IsClientLookingAtBoss);
 	CreateNative("SF2_DidClientEscape", Native_DidClientEscape);
+	CreateNative("SF2_ForceClientEscape", Native_ForceClientEscape);
+	CreateNative("SF2_GetClientFlashlightBatteryLife", Native_GetClientFlashlightBatteryLife);
+	CreateNative("SF2_SetClientFlashlightBatteryLife", Native_SetClientFlashlightBatteryLife);
+	CreateNative("SF2_IsClientUsingFlashlight", Native_IsClientUsingFlashlight);
+	CreateNative("SF2_GetClientSprintPoints", Native_GetClientSprintPoints);
+	CreateNative("SF2_SetClientSprintPoints", Native_SetClientSprintPoints);
+	CreateNative("SF2_IsClientSprinting", Native_IsClientSprinting);
+	CreateNative("SF2_IsClientReallySprinting", Native_IsClientReallySprinting);
+	CreateNative("SF2_IsClientTrapped", Native_IsClientTrapped);
 	CreateNative("SF2_CollectAsPage", Native_CollectAsPage);
 	CreateNative("SF2_GetMaxBossCount", Native_GetMaxBosses);
 	CreateNative("SF2_EntIndexToBossIndex", Native_EntIndexToBossIndex);
@@ -913,12 +938,36 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error,int err_max)
 	CreateNative("SF2_BossIndexToEntIndexEx", Native_BossIndexToEntIndexEx);
 	CreateNative("SF2_BossIDToBossIndex", Native_BossIDToBossIndex);
 	CreateNative("SF2_BossIndexToBossID", Native_BossIndexToBossID);
+	CreateNative("SF2_AddBoss", Native_AddBoss);
+	CreateNative("SF2_RemoveBoss", Native_RemoveBoss);
 	CreateNative("SF2_GetBossName", Native_GetBossName);
+	CreateNative("SF2_GetBossType", Native_GetBossType);
+	CreateNative("SF2_GetBossFlags", Native_GetBossFlags);
+	CreateNative("SF2_SetBossFlags", Native_SetBossFlags);
+	CreateNative("SF2_SpawnBoss", Native_SpawnBoss);
+	CreateNative("SF2_DespawnBoss", Native_DespawnBoss);
 	CreateNative("SF2_GetBossModelEntity", Native_GetBossModelEntity);
 	CreateNative("SF2_GetBossTarget", Native_GetBossTarget);
 	CreateNative("SF2_GetBossMaster", Native_GetBossMaster);
 	CreateNative("SF2_GetBossState", Native_GetBossState);
 	CreateNative("SF2_GetBossFOV", Native_GetBossFOV);
+	CreateNative("SF2_GetBossTimeUntilNoPersistence", Native_GetBossTimeUntilNoPersistence);
+	CreateNative("SF2_SetBossTimeUntilNoPersistence", Native_SetBossTimeUntilNoPersistence);
+	CreateNative("SF2_GetBossTimeUntilIdle", Native_GetBossTimeUntilIdle);
+	CreateNative("SF2_SetBossTimeUntilIdle", Native_SetBossTimeUntilIdle);
+	CreateNative("SF2_GetBossTimeUntilAlert", Native_GetBossTimeUntilAlert);
+	CreateNative("SF2_SetBossTimeUntilAlert", Native_SetBossTimeUntilAlert);
+	CreateNative("SF2_IsBossStunnable", Native_IsBossStunnable);
+	CreateNative("SF2_IsBossStunnableByFlashlight", Native_IsBossStunnableByFlashlight);
+	CreateNative("SF2_IsBossCloaked", Native_IsBossCloaked);
+	CreateNative("SF2_GetBossStunHealth", Native_GetBossStunHealth);
+	CreateNative("SF2_SetBossStunHealth", Native_SetBossStunHealth);
+	CreateNative("SF2_GetBossNextStunTime", Native_GetBossNextStunTime);
+	CreateNative("SF2_SetBossNextStunTime", Native_SetBossNextStunTime);
+	CreateNative("SF2_ForceBossGiveUp", Native_ForceBossGiveUp);
+	CreateNative("SF2_GetBossGoalPosition", Native_GetBossGoalPosition);
+	CreateNative("SF2_CanBossHearClient", Native_CanBossHearClient);
+	CreateNative("SF2_CreateBossSoundHint", Native_CreateBossSoundHint);
 	CreateNative("SF2_IsBossProfileValid", Native_IsBossProfileValid);
 	CreateNative("SF2_GetBossProfileNum", Native_GetBossProfileNum);
 	CreateNative("SF2_GetBossProfileFloat", Native_GetBossProfileFloat);
@@ -926,6 +975,10 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error,int err_max)
 	CreateNative("SF2_GetBossProfileVector", Native_GetBossProfileVector);
 	CreateNative("SF2_GetRandomStringFromBossProfile", Native_GetRandomStringFromBossProfile);
 	CreateNative("SF2_IsSurvivalMap", Native_IsSurvivalMap);
+	CreateNative("SF2_IsBoxingMap", Native_IsBoxingMap);
+	CreateNative("SF2_IsRaidMap", Native_IsRaidMap);
+	CreateNative("SF2_IsProxyMap", Native_IsProxyMap);
+	CreateNative("SF2_IsRenevantMap", Native_IsRenevantMap);
 	
 	PvP_InitializeAPI();
 	
@@ -3716,7 +3769,7 @@ public Action Hook_NormalSound(int clients[64], int &numClients, char sample[PLA
 					{
 						if (NPCGetUniqueID(iBossIndex) == -1) continue;
 						
-						if (SlenderCanHearPlayer(iBossIndex, entity, SoundType_Voice))
+						if (SlenderCanHearPlayer(iBossIndex, entity, SoundType_Voice) && NPCShouldHearEntity(iBossIndex, entity))
 						{
 							GetClientAbsOrigin(entity, g_flSlenderTargetSoundTempPos[iBossIndex]);
 							g_iSlenderInterruptConditions[iBossIndex] |= COND_HEARDSUSPICIOUSSOUND;
@@ -3749,7 +3802,7 @@ public Action Hook_NormalSound(int clients[64], int &numClients, char sample[PLA
 						{
 							if (NPCGetUniqueID(iBossIndex) == -1) continue;
 							
-							if (SlenderCanHearPlayer(iBossIndex, entity, SoundType_Footstep))
+							if (SlenderCanHearPlayer(iBossIndex, entity, SoundType_Footstep) && NPCShouldHearEntity(iBossIndex, entity))
 							{
 								GetClientAbsOrigin(entity, g_flSlenderTargetSoundTempPos[iBossIndex]);
 								g_iSlenderInterruptConditions[iBossIndex] |= COND_HEARDSUSPICIOUSSOUND;
@@ -3772,7 +3825,7 @@ public Action Hook_NormalSound(int clients[64], int &numClients, char sample[PLA
 						{
 							if (NPCGetUniqueID(iBossIndex) == -1) continue;
 							
-							if (SlenderCanHearPlayer(iBossIndex, entity, SoundType_Weapon))
+							if (SlenderCanHearPlayer(iBossIndex, entity, SoundType_Weapon) && NPCShouldHearEntity(iBossIndex, entity))
 							{
 								GetClientAbsOrigin(entity, g_flSlenderTargetSoundTempPos[iBossIndex]);
 								g_iSlenderInterruptConditions[iBossIndex] |= COND_HEARDSUSPICIOUSSOUND;
@@ -3790,7 +3843,7 @@ public Action Hook_NormalSound(int clients[64], int &numClients, char sample[PLA
 						{
 							if (NPCGetUniqueID(iBossIndex) == -1) continue;
 							
-							if (SlenderCanHearPlayer(iBossIndex, entity, SoundType_Flashlight))
+							if (SlenderCanHearPlayer(iBossIndex, entity, SoundType_Flashlight) && NPCShouldHearEntity(iBossIndex, entity))
 							{
 								GetClientAbsOrigin(entity, g_flSlenderTargetSoundTempPos[iBossIndex]);
 								g_iSlenderInterruptConditions[iBossIndex] |= COND_HEARDSUSPICIOUSSOUND;
@@ -5020,6 +5073,11 @@ void SetRoundState(SF2RoundState iRoundState)
 			}
 		}
 	}
+
+	Call_StartForward(fOnRoundStateChange);
+	Call_PushCell(iOldRoundState);
+	Call_PushCell(g_iRoundState);
+	Call_Finish();
 }
 
 bool IsRoundInEscapeObjective()
@@ -5516,6 +5574,10 @@ public Action Timer_SlenderBlinkBossThink(Handle timer, any entref)
 				for (int i = 1; i <= MaxClients; i++)
 				{
 					if (!IsClientInGame(i) || !IsPlayerAlive(i) || IsClientInDeathCam(i) || g_bPlayerEliminated[i] || DidClientEscape(i) || IsClientInGhostMode(i) || !PlayerCanSeeSlender(i, iBossIndex, false, false)) continue;
+					
+					if (!NPCShouldSeeEntity(iBossIndex, i))
+						continue;
+					
 					PushArrayCell(hArray, i);
 				}
 				
@@ -7026,7 +7088,7 @@ public Action Event_PlayerHurt(Handle event, const char[] name, bool dB)
 #endif
 }
 
-public int SF2_OnBossAdded(int iBossIndex)
+public void SF2_OnBossAdded(int iBossIndex)
 {
 	char sProfile[SF2_MAX_PROFILE_NAME_LENGTH];
 	SF2_GetBossName(iBossIndex, sProfile, sizeof(sProfile));
@@ -10092,6 +10154,11 @@ public int Native_GetRoundState(Handle plugin,int numParams)
 	return view_as<int>(g_iRoundState);
 }
 
+public int Native_IsRoundInGracePeriod(Handle plugin, int numParams)
+{
+	return g_bRoundGrace;
+}
+
 public int Native_GetCurrentDifficulty(Handle plugin,int numParams)
 {
 	return GetConVarInt(g_cvDifficulty);
@@ -10138,6 +10205,21 @@ public int Native_GetClientBlinkCount(Handle plugin,int numParams)
 	return ClientGetBlinkCount(GetNativeCell(1));
 }
 
+public int Native_IsClientBlinking(Handle plugin,int numParams)
+{
+	return IsClientBlinking(GetNativeCell(1));
+}
+
+public int Native_GetClientBlinkMeter(Handle plugin,int numParams)
+{
+	return view_as<int>(ClientGetBlinkMeter(GetNativeCell(1)));
+}
+
+public int Native_SetClientBlinkMeter(Handle plugin,int numParams)
+{
+	ClientSetBlinkMeter(GetNativeCell(1), view_as<float>(GetNativeCell(2)));
+}
+
 public int Native_GetClientProxyMaster(Handle plugin,int numParams)
 {
 	return NPCGetFromUniqueID(g_iPlayerProxyMaster[GetNativeCell(1)]);
@@ -10178,6 +10260,54 @@ public int Native_DidClientEscape(Handle plugin,int numParams)
 	return view_as<bool>(DidClientEscape(GetNativeCell(1)));
 }
 
+public int Native_ForceClientEscape(Handle plugin,int numParams)
+{
+	int client = GetNativeCell(1);
+
+	ClientEscape(client);
+	TeleportClientToEscapePoint(client);
+}
+
+public int Native_GetClientFlashlightBatteryLife(Handle plugin, int numParams)
+{
+	return view_as<int>(ClientGetFlashlightBatteryLife(GetNativeCell(1)));
+}
+
+public int Native_SetClientFlashlightBatteryLife(Handle plugin, int numParams)
+{
+	ClientSetFlashlightBatteryLife(GetNativeCell(1), view_as<float>(GetNativeCell(2)));
+}
+
+public int Native_IsClientUsingFlashlight(Handle plugin, int numParams)
+{
+	return IsClientUsingFlashlight(GetNativeCell(1));
+}
+
+public int Native_GetClientSprintPoints(Handle plugin, int numParams)
+{
+	return ClientGetSprintPoints(GetNativeCell(1));
+}
+
+public int Native_SetClientSprintPoints(Handle plugin, int numParams)
+{
+	g_iPlayerSprintPoints[GetNativeCell(1)] = GetNativeCell(2);
+}
+
+public int Native_IsClientSprinting(Handle plugin, int numParams)
+{
+	return IsClientSprinting(GetNativeCell(1));
+}
+
+public int Native_IsClientReallySprinting(Handle plugin, int numParams)
+{
+	return IsClientReallySprinting(GetNativeCell(1));
+}
+
+public int Native_IsClientTrapped(Handle plugin, int numParams)
+{
+	return g_bPlayerTrapped[GetNativeCell(1)];
+}
+
 public int Native_CollectAsPage(Handle plugin,int numParams)
 {
 	CollectPage(GetNativeCell(1), GetNativeCell(2));
@@ -10213,12 +10343,69 @@ public int Native_BossIndexToBossID(Handle plugin,int numParams)
 	return NPCGetUniqueID(GetNativeCell(1));
 }
 
+public int Native_AddBoss(Handle plugin, int numParams)
+{
+	char sProfile[SF2_MAX_PROFILE_NAME_LENGTH];
+	GetNativeString(1, sProfile, sizeof(sProfile));
+
+	int flags = GetNativeCell(2);
+	bool spawnCompanions = view_as<bool>(GetNativeCell(3));
+	bool playSpawnSound = view_as<bool>(GetNativeCell(4));
+
+	return view_as<int>(AddProfile(sProfile, flags, _, spawnCompanions, playSpawnSound));
+}
+
+public int Native_RemoveBoss(Handle plugin, int numParams)
+{
+	SF2NPC_BaseNPC boss = SF2NPC_BaseNPC(GetNativeCell(1));
+	if (!boss.IsValid())
+		return;
+	
+	RemoveProfile(boss.Index);
+}
+
 public int Native_GetBossName(Handle plugin,int numParams)
 {
 	char sProfile[SF2_MAX_PROFILE_NAME_LENGTH];
 	NPCGetProfile(GetNativeCell(1), sProfile, sizeof(sProfile));
 	
 	SetNativeString(2, sProfile, GetNativeCell(3));
+}
+
+public int Native_GetBossType(Handle plugin, int numParams)
+{
+	return NPCGetType(GetNativeCell(1));
+}
+
+public int Native_GetBossFlags(Handle plugin, int numParams)
+{
+	return NPCGetFlags(GetNativeCell(1));
+}
+
+public int Native_SetBossFlags(Handle plugin, int numParams)
+{
+	NPCSetFlags(GetNativeCell(1), GetNativeCell(2));
+}
+
+public int Native_SpawnBoss(Handle plugin, int numParams)
+{
+	SF2NPC_BaseNPC boss = SF2NPC_BaseNPC(GetNativeCell(1));
+	if (!boss.IsValid())
+		return;
+
+	float position[3];
+	GetNativeArray(2, position, 3);
+
+	SpawnSlender(boss, position);
+}
+
+public int Native_DespawnBoss(Handle plugin, int numParams)
+{
+	SF2NPC_BaseNPC boss = SF2NPC_BaseNPC(GetNativeCell(1));
+	if (!boss.IsValid())
+		return;
+
+	RemoveSlender(boss.Index);
 }
 
 public int Native_GetBossModelEntity(Handle plugin,int numParams)
@@ -10244,6 +10431,125 @@ public int Native_GetBossState(Handle plugin,int numParams)
 public int Native_GetBossFOV(Handle plugin, int numParams)
 {
 	return view_as<int>(NPCGetFOV(GetNativeCell(1)));
+}
+
+public int Native_GetBossTimeUntilNoPersistence(Handle plugin, int numParams)
+{
+	return view_as<int>(g_flSlenderTimeUntilNoPersistence[GetNativeCell(1)]);
+}
+
+public int Native_SetBossTimeUntilNoPersistence(Handle plugin, int numParams)
+{
+	g_flSlenderTimeUntilNoPersistence[GetNativeCell(1)] = view_as<float>(GetNativeCell(2));
+}
+
+public int Native_GetBossTimeUntilIdle(Handle plugin, int numParams)
+{
+	return view_as<int>(g_flSlenderTimeUntilIdle[GetNativeCell(1)]);
+}
+
+public int Native_SetBossTimeUntilIdle(Handle plugin, int numParams)
+{
+	g_flSlenderTimeUntilIdle[GetNativeCell(1)] = view_as<float>(GetNativeCell(2));
+}
+
+public int Native_GetBossTimeUntilAlert(Handle plugin, int numParams)
+{
+	return view_as<int>(g_flSlenderTimeUntilAlert[GetNativeCell(1)]);
+}
+
+public int Native_SetBossTimeUntilAlert(Handle plugin, int numParams)
+{
+	g_flSlenderTimeUntilAlert[GetNativeCell(1)] = view_as<float>(GetNativeCell(2));
+}
+
+public int Native_IsBossStunnable(Handle plugin, int numParams)
+{
+	return SF2NPC_Chaser(GetNativeCell(1)).StunEnabled;
+}
+
+public int Native_IsBossStunnableByFlashlight(Handle plugin, int numParams)
+{
+	return SF2NPC_Chaser(GetNativeCell(1)).StunByFlashlightEnabled;
+}
+
+public int Native_IsBossCloaked(Handle plugin, int numParams)
+{
+	return g_bNPCHasCloaked[GetNativeCell(1)];
+}
+
+public int Native_GetBossStunHealth(Handle plugin, int numParams)
+{
+	return view_as<int>(SF2NPC_Chaser(GetNativeCell(1)).StunHealth);
+}
+
+public int Native_SetBossStunHealth(Handle plugin, int numParams)
+{
+	SF2NPC_Chaser(GetNativeCell(1)).StunHealth = view_as<float>(GetNativeCell(2));
+}
+
+public int Native_GetBossNextStunTime(Handle plugin, int numParams)
+{
+	return view_as<int>(g_flSlenderNextStunTime[GetNativeCell(1)]);
+}
+
+public int Native_SetBossNextStunTime(Handle plugin, int numParams)
+{
+	g_flSlenderNextStunTime[GetNativeCell(1)] = view_as<float>(GetNativeCell(2));
+}
+
+public int Native_ForceBossGiveUp(Handle plugin, int numParams)
+{
+	g_bSlenderGiveUp[GetNativeCell(1)] = false;
+}
+
+public int Native_GetBossGoalPosition(Handle plugin, int numParams)
+{
+	SetNativeArray(2, g_flSlenderGoalPos[GetNativeCell(1)], 3);
+}
+
+public int Native_CanBossHearClient(Handle plugin, int numParams)
+{
+	return SlenderCanHearPlayer(GetNativeCell(1), GetNativeCell(2), view_as<SoundType>(GetNativeCell(3)));
+}
+
+public int Native_CreateBossSoundHint(Handle plugin, int numParams)
+{
+	SF2NPC_Chaser boss = SF2NPC_Chaser(GetNativeCell(1));
+	if (!boss.IsValid() || boss.Type != SF2BossType_Chaser || !IsValidEntity(boss.EntIndex))
+		return;
+
+	SoundType soundType = view_as<SoundType>(GetNativeCell(2));
+	float position[3];
+	GetNativeArray(3, position, 3);
+
+	switch (soundType)
+	{
+		case SoundType_Footstep:
+		{
+			CopyVector(position, g_flSlenderTargetSoundTempPos[boss.Index]);
+			g_iSlenderInterruptConditions[boss.Index] |= (COND_HEARDSUSPICIOUSSOUND | COND_HEARDFOOTSTEP);
+			if (boss.State == STATE_ALERT) g_iSlenderAutoChaseCount[boss.Index]++;
+		}
+		case SoundType_Voice:
+		{
+			CopyVector(position, g_flSlenderTargetSoundTempPos[boss.Index]);
+			g_iSlenderInterruptConditions[boss.Index] |= (COND_HEARDSUSPICIOUSSOUND | COND_HEARDVOICE);
+			if (boss.State == STATE_ALERT) g_iSlenderAutoChaseCount[boss.Index]++;
+		}
+		case SoundType_Weapon:
+		{
+			CopyVector(position, g_flSlenderTargetSoundTempPos[boss.Index]);
+			g_iSlenderInterruptConditions[boss.Index] |= (COND_HEARDSUSPICIOUSSOUND | COND_HEARDWEAPON);
+			if (boss.State == STATE_ALERT) g_iSlenderAutoChaseCount[boss.Index]++;
+		}
+		case SoundType_Flashlight:
+		{
+			CopyVector(position, g_flSlenderTargetSoundTempPos[boss.Index]);
+			g_iSlenderInterruptConditions[boss.Index] |= (COND_HEARDSUSPICIOUSSOUND | COND_HEARDFLASHLIGHT);
+			if (boss.State == STATE_ALERT) g_iSlenderAutoChaseCount[boss.Index]++;
+		}
+	}
 }
 
 public int Native_IsBossProfileValid(Handle plugin,int numParams)
@@ -10326,7 +10632,7 @@ public int Native_GetRandomStringFromBossProfile(Handle plugin,int numParams)
 	char[] sBuffer = new char[iBufferLen];
 	
 	int iIndex = GetNativeCell(5);
-	
+
 	bool bSuccess = GetRandomStringFromProfile(sProfile, sKeyValue, sBuffer, iBufferLen, iIndex);
 	SetNativeString(3, sBuffer, iBufferLen);
 	return bSuccess;
@@ -10335,4 +10641,24 @@ public int Native_GetRandomStringFromBossProfile(Handle plugin,int numParams)
 public int Native_IsSurvivalMap(Handle plugin, int numParams)
 {
 	return view_as<int>(SF_IsSurvivalMap());
+}
+
+public int Native_IsBoxingMap(Handle plugin, int numParams)
+{
+	return view_as<int>(SF_IsBoxingMap());
+}
+
+public int Native_IsRaidMap(Handle plugin, int numParams)
+{
+	return view_as<int>(SF_IsRaidMap());
+}
+
+public int Native_IsProxyMap(Handle plugin, int numParams)
+{
+	return view_as<int>(SF_IsProxyMap());
+}
+
+public int Native_IsRenevantMap(Handle plugin, int numParams)
+{
+	return view_as<int>(SF_IsRenevantMap());
 }

--- a/addons/sourcemod/scripting/sf2/client.sp
+++ b/addons/sourcemod/scripting/sf2/client.sp
@@ -2941,6 +2941,8 @@ void ClientResetSprint(int client)
 	if (GetConVarInt(g_cvDebugDetail) > 2) DebugMessage("START ClientResetSprint(%d)", client);
 #endif
 
+	bool bWasSprinting = IsClientSprinting(client);
+
 	g_bPlayerSprint[client] = false;
 	g_iPlayerSprintPoints[client] = 100;
 	g_hPlayerSprintTimer[client] = INVALID_HANDLE;
@@ -2953,6 +2955,13 @@ void ClientResetSprint(int client)
 		ClientSetFOV(client, g_iPlayerDesiredFOV[client]);
 	}
 	
+	if (bWasSprinting)
+	{
+		Call_StartForward(fOnClientStopSprinting);
+		Call_PushCell(client);
+		Call_Finish();
+	}
+
 #if defined DEBUG
 	if (GetConVarInt(g_cvDebugDetail) > 2) DebugMessage("END ClientResetSprint(%d)", client);
 #endif
@@ -2973,6 +2982,10 @@ void ClientStartSprint(int client)
 	
 	SDKHook(client, SDKHook_PreThink, Hook_ClientSprintingPreThink);
 	SDKUnhook(client, SDKHook_PreThink, Hook_ClientRechargeSprintPreThink);
+
+	Call_StartForward(fOnClientStartSprinting);
+	Call_PushCell(client);
+	Call_Finish();
 }
 
 static void ClientSprintTimer(int client, bool bRecharge=false)
@@ -3016,6 +3029,10 @@ void ClientStopSprint(int client)
 	
 	SDKHook(client, SDKHook_PreThink, Hook_ClientRechargeSprintPreThink);
 	SDKUnhook(client, SDKHook_PreThink, Hook_ClientSprintingPreThink);
+
+	Call_StartForward(fOnClientStopSprinting);
+	Call_PushCell(client);
+	Call_Finish();
 }
 
 bool IsClientReallySprinting(int client)
@@ -4748,6 +4765,11 @@ bool IsClientBlinking(int client)
 float ClientGetBlinkMeter(int client)
 {
 	return g_flPlayerBlinkMeter[client];
+}
+
+void ClientSetBlinkMeter(int client, float amount)
+{
+	g_flPlayerBlinkMeter[client] = amount;
 }
 
 int ClientGetBlinkCount(int client)

--- a/addons/sourcemod/scripting/sf2/npc/npc_chaser.sp
+++ b/addons/sourcemod/scripting/sf2/npc/npc_chaser.sp
@@ -1765,6 +1765,12 @@ public Action Timer_SlenderChaseBossThink(Handle timer, any entref)
 							bIsVisible = false;
 						}
 					}
+
+					if (bIsVisible)
+					{
+						bIsVisible = NPCShouldSeeEntity(iBossIndex, i);
+					}
+
 					if (bIsVisible)
 					{
 						flDist = GetVectorDistance(flTraceStartPos, flTraceEndPos);
@@ -1805,6 +1811,12 @@ public Action Timer_SlenderChaseBossThink(Handle timer, any entref)
 							bIsVisible = false;
 						}
 					}
+
+					if (bIsVisible)
+					{
+						bIsVisible = NPCShouldSeeEntity(iBossIndex, i);
+					}
+
 					if (bIsVisible)
 					{
 						flDist = GetVectorDistance(flTraceStartPos, flTraceEndPos);
@@ -1835,6 +1847,11 @@ public Action Timer_SlenderChaseBossThink(Handle timer, any entref)
 		
 		if (!bIsVisible && iTraceHitEntity == i) bIsVisible = true;
 		
+		if (bIsVisible)
+		{
+			bIsVisible = NPCShouldSeeEntity(iBossIndex, i);
+		}
+
 		bPlayerVisible[i] = bIsVisible;
 		
 		// Near radius check.
@@ -5113,6 +5130,11 @@ public void SlenderChaseBossProcessMovement(int iBoss)
 						}
 					}
 					
+					if (bCanSeeTarget)
+					{
+						bCanSeeTarget = NPCShouldSeeEntity(iBossIndex, iTarget);
+					}
+
 					if (NPCHasAttribute(iBossIndex, "always look at target while chasing") || bCanSeeTarget)
 					{
 						if (iTarget && iTarget != INVALID_ENT_REFERENCE)

--- a/addons/sourcemod/scripting/sf2/pvp.sp
+++ b/addons/sourcemod/scripting/sf2/pvp.sp
@@ -64,6 +64,9 @@ enum struct PvPProjectile_BallOfFire
 
 	void OnTouchPost(int otherEntity)
 	{
+		if (IsRoundEnding())
+			return;
+
 		int ent = this.EntIndex;
 		int ownerEntity = GetEntPropEnt(ent, Prop_Data, "m_hOwnerEntity");
 		if (!IsValidClient(ownerEntity) || otherEntity == ownerEntity || !IsClientInPvP(ownerEntity))


### PR DESCRIPTION
`sf2.inc` looked like it was overdue for an upgrade, so I updated the syntax of the include file (it was still using old-style tags and whatnot), and created a handful of useful forwards and natives that external plugins can use. The list of forwards and natives is in the commit as there's too many to list here. Some of them such as `SF2_OnBoss(De)Spawn` and `SF2_OnRoundStateChange` were directly inspired from Glubbable's private SF2, but most of them just expose already existing functions within SF2 already.

`SF2_OnClientBlink` was misspelled as `SF2_OnClientBlinked` which was why the forward wasn't firing, so the forward is now `SF2_OnClientBlink`.

Also, minor fix to Dragon's Fury damaging players at end of round in PvP. I got a kick out of ~~abusing~~ testing it out for a while but it had to be done.