### PR TITLE
Map Entities Update

### DIFF
--- a/addons/sourcemod/gamedata/sf2.txt
+++ b/addons/sourcemod/gamedata/sf2.txt
@@ -60,6 +60,11 @@
 				"linux"    	"140"
 				"windows"       "139"
 			}
+			"CBaseEntity::KeyValue"
+			{
+				"linux"		"30"
+				"windows"	"31"
+			}
 			"CBaseAnimating::StudioFrameAdvance"
 			{
 				"linux"		"194"
@@ -296,6 +301,11 @@
 				"linux"		"34"
 				"windows"	"34"
 			}
+			"CBaseTrigger::PassesTriggerFilters"
+			{
+				"linux"		"201"
+				"windows"	"200"
+			}
 		}
 		"Signatures"
 		{
@@ -344,6 +354,14 @@
 				"library"	 "server"
 				"linux"		"@_ZN12CBaseTrigger13PointIsWithinERK6Vector"
 				"windows" 	"\x53\x8B\xDC\x83\xEC\x2A\x83\xE4\x2A\x83\xC4\x2A\x55\x8B\x6B\x2A\x89\x6C\x2A\x2A\x8B\xEC\x81\xEC\x2A\x2A\x2A\x2A\x8B\x43\x2A\x56\x50\x8B\xF1"
+			}
+
+			// "CreateEntityByName( %s, %d ) - CreateEdict failed."
+			"CreateEntityByName"
+			{
+				"library"	"server"
+				"linux"		"@_Z18CreateEntityByNamePKci"
+				"windows"	"\x2A\x2A\x2A\x2A\x2A\x2A\x0C\x83\xFE\xFF\x74\x24\x8B\x0D"
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/sf2/entities.sp
+++ b/addons/sourcemod/scripting/sf2/entities.sp
@@ -1,0 +1,1125 @@
+#if defined _sf2_mapentities_included
+ #endinput
+#endif
+#define _sf2_mapentities_included
+
+//#define DEBUG_MAPENTITIES
+
+static bool g_bCustomEntity = false;
+static char g_sCustomEntityOriginalClass[PLATFORM_MAX_PATH];
+
+static ArrayList g_hCustomEntities;
+
+static DynamicHook g_hSDKAcceptInput;
+static DynamicHook g_hSDKKeyValue;
+static DynamicDetour g_hSDKCreateEntityByName;
+
+static PrivateForward g_CustomEntityTranslateClassname;
+static PrivateForward g_CustomEntityInitialize;
+static PrivateForward g_CustomEntityOnLevelInit;
+static PrivateForward g_CustomEntityOnMapStart;
+static PrivateForward g_CustomEntityOnAcceptEntityInput;
+static PrivateForward g_CustomEntityOnEntityKeyValue;
+static PrivateForward g_CustomEntityOnRoundStateChanged;
+static PrivateForward g_CustomEntityOnGracePeriodEnd;
+static PrivateForward g_CustomEntityOnDestroyed;
+static PrivateForward g_CustomEntityOnDifficultyChanged;
+static PrivateForward g_CustomEntityOnPageCountChanged;
+
+static PrivateForward g_CustomEntityOnRenevantWaveTriggered;
+
+static Handle g_hSDKPassesTriggerFilters;
+
+/**
+ *	A struct to be used with SF2MapEntity.FireOutput
+ */
+enum struct SF2MapEntityVariant
+{
+	int FieldType;
+	int IntValue;
+	float FloatValue;
+	char StringValue[PLATFORM_MAX_PATH];
+
+	void Init() 
+	{
+		this.FieldType = 0;
+		this.IntValue = 0;
+		this.FloatValue = 0.0;
+		this.StringValue[0] = '\0';
+	}
+
+	void SetInt(int value) 
+	{
+		this.FieldType = 5;
+		this.IntValue = value;
+	}
+
+	void SetFloat(float value) {
+		this.FieldType = 1;
+		this.FloatValue = value;
+	}
+
+	void SetString(const char[] value) {
+		this.FieldType = 2;
+		strcopy(this.StringValue, PLATFORM_MAX_PATH, value);
+	}
+}
+
+static void SF2MapEntityVariant_Copy(SF2MapEntityVariant dest, SF2MapEntityVariant src)
+{
+	dest.FieldType = src.FieldType;
+	dest.IntValue = src.IntValue;
+	dest.FloatValue = src.FloatValue;
+	strcopy(dest.StringValue, PLATFORM_MAX_PATH, src.StringValue);
+}
+
+/**
+ * A custom map entity for SF2.
+ */
+methodmap SF2MapEntity
+{
+	public SF2MapEntity(int entIndex) 
+	{
+		return view_as<SF2MapEntity>(EnsureEntRef(entIndex));
+	}
+
+	property int EntRef 
+	{
+		public get()
+		{ 
+			return view_as<int>(this);
+		}
+	}
+
+	property int EntIndex
+	{
+		public get()
+		{
+			int entIndex = view_as<int>(this);
+			return (entIndex & (1 << 31)) ? EntRefToEntIndex(entIndex) : entIndex;
+		}
+	}
+
+	public bool IsValid()
+	{
+		return IsValidEntity(this.EntRef);
+	}
+
+	public void AddOutput(const char[] szKeyName, const char[] szValue)
+	{
+		SF2MapEntity_AddOutput(this.EntRef, szKeyName, szValue);
+	}
+
+	public void FireOutput(const char[] szKeyName, int activator, int caller, SF2MapEntityVariant inputVariant)
+	{
+		SF2MapEntity_FireOutput(this.EntRef, szKeyName, activator, caller, inputVariant);
+	}
+
+	public void FireOutputNoVariant(const char[] szKeyName, int activator, int caller)
+	{
+		SF2MapEntityVariant inputVariant;
+		inputVariant.Init();
+
+		SF2MapEntity_FireOutput(this.EntRef, szKeyName, activator, caller, inputVariant);
+	}
+}
+
+methodmap SF2TriggerMapEntity < SF2MapEntity
+{
+	public SF2TriggerMapEntity(int entIndex)
+	{
+		return view_as<SF2TriggerMapEntity>(SF2MapEntity(entIndex));
+	}
+
+	public bool PassesTriggerFilters(int entity)
+	{
+		return view_as<bool>(SDKCall(g_hSDKPassesTriggerFilters, this.EntIndex, entity));
+	}
+
+	property bool IsDisabled
+	{
+		public get()
+		{
+			return view_as<bool>(GetEntProp(this.EntRef, Prop_Data, "m_bDisabled")); 
+		}
+	}
+}
+
+enum SF2MapEntityHook
+{
+	SF2MapEntityHook_OnLevelInit = 0,
+	SF2MapEntityHook_TranslateClassname,
+	SF2MapEntityHook_OnEntityCreated,
+	SF2MapEntityHook_OnEntityDestroyed,
+	SF2MapEntityHook_OnMapStart,
+	SF2MapEntityHook_OnEntityKeyValue,
+	SF2MapEntityHook_OnAcceptEntityInput,
+	SF2MapEntityHook_OnRoundStateChanged,
+	SF2MapEntityHook_OnGracePeriodEnd,
+	SF2MapEntityHook_OnDifficultyChanged,
+	SF2MapEntityHook_OnPageCountChanged,
+	SF2MapEntityHook_OnRenevantWaveTriggered,
+	SF2MapEntityHook_Max
+}
+
+void SF2MapEntity_AddHook(SF2MapEntityHook hookType, Function hookFunc)
+{
+	switch (hookType)
+	{
+		case SF2MapEntityHook_OnLevelInit:
+			g_CustomEntityOnLevelInit.AddFunction(INVALID_HANDLE, hookFunc);
+		case SF2MapEntityHook_TranslateClassname:
+			g_CustomEntityTranslateClassname.AddFunction(INVALID_HANDLE, hookFunc);
+		case SF2MapEntityHook_OnEntityCreated:
+			g_CustomEntityInitialize.AddFunction(INVALID_HANDLE, hookFunc);
+		case SF2MapEntityHook_OnEntityDestroyed:
+			g_CustomEntityOnDestroyed.AddFunction(INVALID_HANDLE, hookFunc);
+		case SF2MapEntityHook_OnMapStart:
+			g_CustomEntityOnMapStart.AddFunction(INVALID_HANDLE, hookFunc);
+		case SF2MapEntityHook_OnEntityKeyValue:
+			g_CustomEntityOnEntityKeyValue.AddFunction(INVALID_HANDLE, hookFunc);
+		case SF2MapEntityHook_OnAcceptEntityInput:
+			g_CustomEntityOnAcceptEntityInput.AddFunction(INVALID_HANDLE, hookFunc);
+		case SF2MapEntityHook_OnRoundStateChanged:
+			g_CustomEntityOnRoundStateChanged.AddFunction(INVALID_HANDLE, hookFunc);
+		case SF2MapEntityHook_OnGracePeriodEnd:
+			g_CustomEntityOnGracePeriodEnd.AddFunction(INVALID_HANDLE, hookFunc);
+		case SF2MapEntityHook_OnDifficultyChanged:
+			g_CustomEntityOnDifficultyChanged.AddFunction(INVALID_HANDLE, hookFunc);
+		case SF2MapEntityHook_OnPageCountChanged:
+			g_CustomEntityOnPageCountChanged.AddFunction(INVALID_HANDLE, hookFunc);
+		
+		case SF2MapEntityHook_OnRenevantWaveTriggered:
+			g_CustomEntityOnRenevantWaveTriggered.AddFunction(INVALID_HANDLE, hookFunc);
+		
+		default:
+			ThrowError("Unhandled hooktype %i", hookType);
+	}
+}
+
+#include "sf2/entities/sf2_game_text.sp"
+#include "sf2/entities/sf2_gamerules.sp"
+#include "sf2/entities/sf2_trigger_escape.sp"
+#include "sf2/entities/sf2_info_player_escapespawn.sp"
+#include "sf2/entities/sf2_trigger_pvp.sp"
+#include "sf2/entities/sf2_info_player_pvpspawn.sp"
+#include "sf2/entities/sf2_info_player_proxyspawn.sp"
+#include "sf2/entities/sf2_info_boss_spawn.sp"
+#include "sf2/entities/sf2_info_page_spawn.sp"
+#include "sf2/entities/sf2_info_page_music.sp"
+#include "sf2/entities/sf2_logic_proxy.sp"
+#include "sf2/entities/sf2_logic_raid.sp"
+
+// Modified only
+#include "sf2/entities/sf2_logic_arena.sp"
+#include "sf2/entities/sf2_logic_boxing.sp"
+#include "sf2/entities/sf2_logic_slaughter.sp"
+
+/**
+ * A single output that is registered to the entity using AddOutput.
+ */
+enum struct SF2MapEntityOutputData
+{
+	int ID;
+	char Output[256];
+	char TargetName[256];
+	char Input[256];
+	char InputParameter[256];
+	float Delay;
+	int TimesToFire;
+
+	void Init() 
+	{
+		this.Output[0] = '\0';
+		this.TargetName[0] = '\0';
+		this.Input[0] = '\0';
+		this.InputParameter[0] = '\0';
+		this.Delay = 0.0;
+		this.TimesToFire = -1; // EVENT_FIRE_ALWAYS
+	}
+}
+
+/**
+ * A structure that contains an event to fire a specific output on the entity when the associated timer elapses.
+ */
+enum struct SF2MapEntityFireOutputData
+{
+	Handle TimerHandle;
+	int ActivatorEntRef;
+	int CallerEntRef;
+	int OutputID;
+	SF2MapEntityVariant Variant;
+}
+
+/**
+ * Internal data stored for a custom map entity.
+ */
+enum struct SF2MapEntityData
+{
+	int EntRef; 
+	char Classname[PLATFORM_MAX_PATH];
+	ArrayList Outputs;
+	ArrayList FiredOutputs;
+	int OutputIDStamp;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+		this.Classname[0] = '\0';
+		this.Outputs = new ArrayList(sizeof(SF2MapEntityOutputData));
+		this.FiredOutputs = new ArrayList(sizeof(SF2MapEntityFireOutputData));
+		this.OutputIDStamp = 0;
+	}
+
+	void Destroy() 
+	{
+		if (this.Outputs != null) 
+		{
+			delete this.Outputs;
+			this.Outputs = null;
+		}
+
+		if (this.FiredOutputs != null) 
+		{
+			delete this.FiredOutputs;
+			this.FiredOutputs = null;
+		}
+	}
+}
+
+// BUG: Can't use sizeof(enum struct) operator inside a function in the same enum struct for some god awful reason, 
+// so we have to put this function out here instead.
+static int SF2MapEntityData_Get(int entIndex, SF2MapEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_hCustomEntities.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_hCustomEntities.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+static void SF2MapEntityData_Update(SF2MapEntityData entData)
+{
+	int iIndex = g_hCustomEntities.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_hCustomEntities.SetArray(iIndex, entData, sizeof(entData));
+}
+
+void SF2MapEntity_Initialize()
+{
+	g_CustomEntityTranslateClassname = new PrivateForward(ET_Event, Param_String, Param_String, Param_Cell);
+	g_CustomEntityInitialize = new PrivateForward(ET_Ignore, Param_Cell, Param_String);
+	g_CustomEntityOnAcceptEntityInput = new PrivateForward(ET_Event, Param_Cell, Param_String, Param_String, Param_Cell, Param_Cell);
+	g_CustomEntityOnEntityKeyValue = new PrivateForward(ET_Event, Param_Cell, Param_String, Param_String, Param_String);
+	g_CustomEntityOnLevelInit = new PrivateForward(ET_Ignore, Param_String);
+	g_CustomEntityOnMapStart = new PrivateForward(ET_Ignore);
+	g_CustomEntityOnDestroyed = new PrivateForward(ET_Ignore, Param_Cell, Param_String);
+	g_CustomEntityOnRoundStateChanged = new PrivateForward(ET_Ignore, Param_Cell, Param_Cell);
+	g_CustomEntityOnGracePeriodEnd = new PrivateForward(ET_Ignore);
+	g_CustomEntityOnDifficultyChanged = new PrivateForward(ET_Ignore, Param_Cell, Param_Cell);
+	g_CustomEntityOnPageCountChanged = new PrivateForward(ET_Ignore, Param_Cell, Param_Cell);
+
+	g_CustomEntityOnRenevantWaveTriggered = new PrivateForward(ET_Ignore, Param_Cell);
+
+	g_hCustomEntities = new ArrayList(sizeof(SF2MapEntityData));
+
+	g_cvDifficulty.AddChangeHook(SF2MapEntity_OnDifficultyChanged);
+
+	// Initialize static entity data.
+	// Unfortunately, there's no better way to do it other than sticking the initialization functions here.
+
+	// sf2_game_text
+	SF2GameTextEntity_Initialize();
+
+	// sf2_gamerules
+	SF2GamerulesEntity_Initialize();
+
+	// sf2_trigger_escape
+	SF2TriggerEscapeEntity_Initialize();
+
+	// sf2_info_player_escapespawn
+	SF2PlayerEscapeSpawnEntity_Initialize();
+
+	// sf2_trigger_pvp
+	SF2TriggerPvPEntity_Initialize();
+
+	// sf2_info_player_pvpspawn
+	SF2PlayerPvPSpawnEntity_Initialize();
+
+	// sf2_info_player_proxyspawn
+	SF2PlayerProxySpawnEntity_Initialize();
+
+	// sf2_info_boss_spawn
+	SF2BossSpawnEntity_Initialize();
+
+	// sf2_info_page_spawn
+	SF2PageSpawnEntity_Initialize();
+
+	// sf2_info_page_music
+	SF2PageMusicEntity_Initialize();
+
+	// sf2_logic_proxy
+	SF2LogicProxyEntity_Initialize();
+
+	// sf2_logic_raid
+	SF2LogicRaidEntity_Initialize();
+
+	// Modified
+	
+	// sf2_logic_renevant
+	SF2LogicRenevantEntity_Initialize();
+
+	// sf2_logic_boxing
+	SF2LogicBoxingEntity_Initialize();
+
+	// sf2_logic_slaughter
+	SF2LogicSlaughterEntity_Initialize();
+}
+
+void SF2MapEntity_OnLevelInit(const char[] sMapName) 
+{
+	if (g_hCustomEntities.Length > 0) 
+	{
+		LogSF2Message("WARNING: Some custom entities did not destroy correctly. Cleaning up...");
+
+		for (int i = 0; i < g_hCustomEntities.Length; i++) {
+			SF2MapEntityData entData;
+			g_hCustomEntities.GetArray(i, entData, sizeof(entData));
+			entData.Destroy();
+		}
+
+		g_hCustomEntities.Clear();
+	}
+
+	Call_StartForward(g_CustomEntityOnLevelInit);
+	Call_PushString(sMapName);
+	Call_Finish();
+}
+
+void SF2MapEntity_OnMapStart()
+{
+	Call_StartForward(g_CustomEntityOnMapStart);
+	Call_Finish();
+}
+
+static bool SF2MapEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen) 
+{
+	Action result = Plugin_Continue;
+
+	Call_StartForward(g_CustomEntityTranslateClassname);
+	Call_PushString(sClass);
+	Call_PushStringEx(sBuffer, iBufferLen, SM_PARAM_STRING_COPY, SM_PARAM_COPYBACK);
+	Call_PushCell(iBufferLen);
+	Call_Finish(result);
+
+	return (result != Plugin_Continue);
+}
+
+static MRESReturn SF2MapEntity_OnCreateEntityByNamePre(DHookReturn hReturn, DHookParam hParams)
+{
+	char sClass[PLATFORM_MAX_PATH];
+	hParams.GetString(1, sClass, sizeof(sClass));
+
+	char sTranslatedClass[PLATFORM_MAX_PATH];
+	if (SF2MapEntity_TranslateClassname(sClass, sTranslatedClass, sizeof(sTranslatedClass)))
+	{
+		g_bCustomEntity = true;
+		strcopy(g_sCustomEntityOriginalClass, sizeof(g_sCustomEntityOriginalClass), sClass);
+
+		hParams.SetString(1, sTranslatedClass);
+
+#if defined DEBUG_MAPENTITIES
+		PrintToServer("Translated custom entity classname from %s -> %s", sClass, sTranslatedClass);
+#endif
+
+		return MRES_ChangedHandled;
+	}
+
+	return MRES_Ignored;
+}
+
+static MRESReturn SF2MapEntity_OnCreateEntityByNamePost(DHookReturn hReturn, DHookParam hParams)
+{
+	int entity = hReturn.Value;
+
+	if (g_bCustomEntity) 
+	{
+		g_bCustomEntity = false;
+
+		if (IsValidEntity(entity))
+		{
+			SF2MapEntityData entData;
+			entData.Init(entity);
+
+			strcopy(entData.Classname, sizeof(entData.Classname), g_sCustomEntityOriginalClass);
+
+			g_hCustomEntities.PushArray(entData, sizeof(entData));
+
+			Call_StartForward(g_CustomEntityInitialize);
+			Call_PushCell(entity);
+			Call_PushString(g_sCustomEntityOriginalClass);
+			Call_Finish();
+
+			SetEntPropString(entity, Prop_Data, "m_iClassname", g_sCustomEntityOriginalClass);
+
+			g_hSDKAcceptInput.HookEntity(Hook_Pre, entity, SF2MapEntity_OnAcceptEntityInputPre);
+			g_hSDKKeyValue.HookEntity(Hook_Pre, entity, SF2MapEntity_OnEntityKeyValuePre);
+
+#if defined DEBUG_MAPENTITIES
+			PrintToServer("Created custom entity %d (%s)", 
+				EntRefToEntIndex(entData.EntRef), entData.Classname);
+#endif
+		}
+	}
+
+	return MRES_Ignored;
+}
+
+static DHookParam g_CustomEntityAcceptInputParams;
+
+/**
+ *	Returns the type stored in the variant_t structure.
+ *	Enum values can be found in source-sdk-2013/sp/src/public/datamap.h
+ */
+static int SF2MapEntity_GetVariantType() {
+	return g_CustomEntityAcceptInputParams.GetObjectVar(4, 16, ObjectValueType_Int);
+}
+
+stock float SF2MapEntity_GetVariantFloat() 
+{
+	if (!g_CustomEntityAcceptInputParams)
+		return 0.0;
+
+	int fieldType = SF2MapEntity_GetVariantType();
+	if (fieldType != 1) // FIELD_FLOAT
+		return 0.0;
+	
+	return g_CustomEntityAcceptInputParams.GetObjectVar(4, 0, ObjectValueType_Float);
+}
+
+stock int SF2MapEntity_GetVariantInt() 
+{
+	if (!g_CustomEntityAcceptInputParams)
+		return 0;
+
+	int fieldType = SF2MapEntity_GetVariantType();
+	if (fieldType != 5) // FIELD_INTEGER
+		return 0;
+	
+	return g_CustomEntityAcceptInputParams.GetObjectVar(4, 0, ObjectValueType_Int);
+}
+
+stock void SF2MapEntity_GetVariantString(char[] sBuffer, int iBufferLen)
+{
+	if (!g_CustomEntityAcceptInputParams)
+		return;
+
+	int fieldType = SF2MapEntity_GetVariantType();
+	if (fieldType != 2) // FIELD_STRING
+	{
+		strcopy(sBuffer, iBufferLen, "");
+		return;
+	}
+
+	g_CustomEntityAcceptInputParams.GetObjectVarString(4, 0, ObjectValueType_CharPtr, sBuffer, iBufferLen);
+}
+
+/**
+ *	Converts the variant value into a float.
+ */
+stock float SF2MapEntity_GetFloatFromVariant()
+{
+	if (!g_CustomEntityAcceptInputParams)
+		return 0.0;
+	
+	switch (SF2MapEntity_GetVariantType()) 
+	{
+		case 1:
+		{
+			return SF2MapEntity_GetVariantFloat();	
+		}
+		case 2:
+		{
+			char sVariant[SF2_MAX_PROFILE_NAME_LENGTH];
+			SF2MapEntity_GetVariantString(sVariant, sizeof(sVariant));
+
+			return StringToFloat(sVariant);
+		}
+		case 5:
+		{
+			return float(SF2MapEntity_GetVariantInt());	
+		}
+	}
+
+	return 0.0;
+}
+
+/**
+ *	Converts the variant value into an integer.
+ */
+stock int SF2MapEntity_GetIntFromVariant()
+{
+	if (!g_CustomEntityAcceptInputParams)
+		return 0;
+	
+	switch (SF2MapEntity_GetVariantType()) 
+	{
+		case 1:
+		{
+			return RoundToZero(SF2MapEntity_GetVariantFloat());
+		}
+		case 2:
+		{
+			char sVariant[SF2_MAX_PROFILE_NAME_LENGTH];
+			SF2MapEntity_GetVariantString(sVariant, sizeof(sVariant));
+
+			return StringToInt(sVariant);
+		}
+		case 5:
+		{
+			return SF2MapEntity_GetVariantInt();	
+		}
+	}
+
+	return 0;
+}
+
+/**
+ *	Converts the variant value into a string.
+ */
+stock void SF2MapEntity_GetStringFromVariant(char[] sBuffer, int iBufferSize)
+{
+	sBuffer[0] = '\0';
+
+	if (!g_CustomEntityAcceptInputParams)
+		return;
+	
+	switch (SF2MapEntity_GetVariantType()) 
+	{
+		case 1:
+		{
+			FloatToString(SF2MapEntity_GetVariantFloat(), sBuffer, iBufferSize);
+		}
+		case 2:
+		{
+			SF2MapEntity_GetVariantString(sBuffer, iBufferSize);
+		}
+		case 5:
+		{
+			IntToString(SF2MapEntity_GetVariantInt(), sBuffer, iBufferSize);
+		}
+	}
+}
+
+static MRESReturn SF2MapEntity_OnAcceptEntityInputPre(int entity, DHookReturn hReturn, DHookParam hParams)
+{
+	if (!IsValidEntity(entity))
+		return MRES_Ignored;
+
+	g_CustomEntityAcceptInputParams = hParams;
+
+	Action result = Plugin_Continue;
+
+	SF2MapEntityData entData;
+	if (SF2MapEntityData_Get(entity, entData) == -1)
+		return MRES_Ignored; // random bug again...
+
+	char szInputName[64];
+	hParams.GetString(1, szInputName, sizeof(szInputName));
+
+	int activator = hParams.IsNull(2) ? -1 : hParams.Get(2);
+	int caller = hParams.IsNull(3) ? -1 : hParams.Get(3);
+
+#if defined DEBUG_MAPENTITIES
+
+	PrintToServer("Custom entity %i receieved input %s (activator: %i, caller: %i)",
+		EntRefToEntIndex(entData.EntRef), szInputName, activator, caller);
+
+#endif
+
+	Call_StartForward(g_CustomEntityOnAcceptEntityInput);
+	Call_PushCell(entity);
+	Call_PushString(entData.Classname);
+	Call_PushString(szInputName);
+	Call_PushCell(activator);
+	Call_PushCell(caller);
+	Call_Finish(result);
+
+	g_CustomEntityAcceptInputParams = null;
+
+	if (result != Plugin_Continue) 
+	{
+		hReturn.Value = true;
+		return MRES_Supercede;
+	}
+
+	return MRES_Ignored;
+}
+
+static MRESReturn SF2MapEntity_OnEntityKeyValuePre(int entity, DHookReturn hReturn, DHookParam hParams)
+{
+	if (!IsValidEntity(entity))
+		return MRES_Ignored;
+
+	SF2MapEntityData entData;
+	if (SF2MapEntityData_Get(entity, entData) == -1)
+	{
+		// BUGFIX: Sometimes, the hook gets called on a completely unrelated entity on level init randomly. What the hell.
+		// DHooks probably forgot to auto unhook. If it happens just ignore.
+		return MRES_Ignored;
+	}
+
+	char szKeyName[PLATFORM_MAX_PATH];
+	hParams.GetString(1, szKeyName, sizeof(szKeyName));
+
+	char szValue[PLATFORM_MAX_PATH];
+	hParams.GetString(2, szValue, sizeof(szValue));
+
+	Action result = Plugin_Continue;
+
+	Call_StartForward(g_CustomEntityOnEntityKeyValue);
+	Call_PushCell(entity);
+	Call_PushString(entData.Classname);
+	Call_PushString(szKeyName);
+	Call_PushString(szValue);
+	Call_Finish(result);
+
+	if (result != Plugin_Continue) 
+	{
+		hReturn.Value = true;
+		return MRES_Supercede;
+	}
+
+	return MRES_Ignored;
+}
+
+static void SF2MapEntity_FireOutput(int entity, const char[] szKeyName, int activator, int caller, SF2MapEntityVariant inputVariant)
+{
+	if (!IsValidEntity(entity))
+		return;
+	
+	SF2MapEntityData entData;
+	if (SF2MapEntityData_Get(entity, entData) == -1)
+		ThrowError("invalid entdata");
+
+	// Ensure activator and caller are entity indices.
+	activator = IsValidEntity(activator) ? ( (activator & (1 << 31)) ? EntRefToEntIndex(activator) : activator ) : -1;
+	caller = IsValidEntity(caller) ? ( (caller & (1 << 31)) ? EntRefToEntIndex(caller) : caller ) : -1;
+
+#if defined DEBUG_MAPENTITIES
+
+	PrintToServer("Custom entity %i (%s) fired output %s (activator: %d, caller: %i)", 
+		EntRefToEntIndex(entData.EntRef), entData.Classname, szKeyName, activator, caller);
+
+#endif
+
+	// need to clone because DoOutputEvent with no delay could affect array size mid-loop
+	ArrayList outputs = entData.Outputs.Clone();
+
+	for (int i = 0; i < outputs.Length; i++) 
+	{
+		SF2MapEntityOutputData outputData;
+		outputs.GetArray(i, outputData, sizeof(outputData));
+
+		if (strcmp(szKeyName, outputData.Output, false) != 0)
+			continue;
+		
+#if defined DEBUG_MAPENTITIES
+		
+		PrintToServer(" - ID: %i\n - Output: %s\n - TargetName: %s\n - Input: %s\n - Input param: %s\n - Delay: %f\n - TimesToFire: %i",
+			outputData.ID, outputData.Output, outputData.TargetName, outputData.Input, outputData.InputParameter, outputData.Delay, outputData.TimesToFire);
+		
+#endif
+
+		SF2MapEntityVariant outputVariant;
+		outputVariant.Init();
+
+		if (outputData.InputParameter[0] == '\0')
+			SF2MapEntityVariant_Copy(outputVariant, inputVariant);
+		else 
+			outputVariant.SetString(outputData.InputParameter);
+
+		if (outputData.Delay <= 0.0) 
+		{
+			SF2MapEntity_DoOutputEvent(entity, outputData.ID, activator, caller, outputVariant);
+		}
+		else 
+		{
+			SF2MapEntityFireOutputData fireOutputData;
+			fireOutputData.TimerHandle = CreateTimer(outputData.Delay, SF2MapEntity_TimerDoOutputEvent, entData.EntRef, TIMER_FLAG_NO_MAPCHANGE);
+			fireOutputData.ActivatorEntRef = IsValidEntity(activator) ? EntIndexToEntRef(activator) : INVALID_ENT_REFERENCE;
+			fireOutputData.CallerEntRef = IsValidEntity(caller) ? EntIndexToEntRef(caller) : INVALID_ENT_REFERENCE;
+			fireOutputData.OutputID = outputData.ID;
+			SF2MapEntityVariant_Copy(fireOutputData.Variant, outputVariant);
+
+			entData.FiredOutputs.PushArray(fireOutputData);
+		}
+	}
+
+	delete outputs;
+}
+
+static Action SF2MapEntity_TimerDoOutputEvent(Handle timer, any data)
+{
+	int entity = EntRefToEntIndex(data);
+	if (entity == INVALID_ENT_REFERENCE)
+		return Plugin_Handled;
+	
+	SF2MapEntityData entData;
+	if (SF2MapEntityData_Get(entity, entData) == -1)
+		ThrowError("invalid entdata");
+
+	int iFiredOutputIndex = entData.FiredOutputs.FindValue(timer);
+	if (iFiredOutputIndex == -1)
+		return Plugin_Handled;
+	
+	SF2MapEntityFireOutputData fireOutputData;
+	entData.FiredOutputs.GetArray(iFiredOutputIndex, fireOutputData, sizeof(fireOutputData));
+	entData.FiredOutputs.Erase(iFiredOutputIndex);
+
+	int activator = fireOutputData.ActivatorEntRef != INVALID_ENT_REFERENCE ?
+		EntRefToEntIndex(fireOutputData.ActivatorEntRef) : -1;
+	int caller = fireOutputData.CallerEntRef != INVALID_ENT_REFERENCE ?
+		EntRefToEntIndex(fireOutputData.CallerEntRef) : -1;
+	
+	SF2MapEntity_DoOutputEvent(entity, fireOutputData.OutputID, activator, caller, fireOutputData.Variant);
+
+	return Plugin_Handled;
+}
+
+static int SF2MapEntity_FindProceduralTarget(const char[] szName, int searchingEntity, int activator, int caller)
+{
+	if (szName[0] != '!')
+		return -1;
+	
+	if ( strcmp( szName, "!activator" ) == 0 )
+	{
+		return activator;
+	}
+	else if ( strcmp( szName, "!caller" ) == 0)
+	{
+		return caller;
+	}
+	else if ( strcmp( szName, "!self" ) == 0)
+	{
+		return searchingEntity;
+	}
+	else 
+	{
+		char sClass[PLATFORM_MAX_PATH];
+		if (IsValidEntity(searchingEntity))
+			GetEntPropString(searchingEntity, Prop_Data, "m_iClassname", sClass, sizeof(sClass));
+		else
+		{
+			strcopy(sClass, sizeof(sClass), "NULL Entity");
+		}
+
+		// Normally if you enter an invalid procedural name the game would just crash.
+		// For custom entities we'll just spit out a message in console instead.
+		// So much nicer, don't you think?
+
+		LogSF2Message("%i (%s): Invalid entity search name %s", searchingEntity, sClass, szName);
+	}
+	
+	return -1;
+}
+
+int SF2MapEntity_FindEntityByTargetname(int startEnt, const char[] szName, int searchingEntity, int activator, int caller)
+{
+	if (szName[0] == '!')
+	{
+		if (startEnt == -1)
+		{
+			int target = SF2MapEntity_FindProceduralTarget(szName, searchingEntity, activator, caller);
+			if (IsValidEntity(target)) 
+			{
+				return target;
+			}
+		}
+
+		return -1;
+	}
+
+	char sTargetName[PLATFORM_MAX_PATH];
+
+	// dear god
+
+	int iMaxEntities = GetMaxEntities() * 2; // multiply by 2 to get non-networked entities too
+	for (int i = startEnt + 1; i < iMaxEntities; i++)
+	{
+		if (!IsValidEntity(i))
+			continue;
+
+		GetEntPropString(i, Prop_Data, "m_iName", sTargetName, sizeof(sTargetName));
+		if (strcmp(sTargetName, szName) == 0) 
+		{
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+static void SF2MapEntity_SetupVariantForInput(const char[] szParam, SF2MapEntityVariant inputVariant)
+{
+	if (szParam[0] != '\0')
+	{
+		SetVariantString(szParam);
+	}
+	else 
+	{
+		switch (inputVariant.FieldType)
+		{
+			case 1: // FIELD_FLOAT
+			{
+				SetVariantFloat(inputVariant.FloatValue);
+			}
+			case 2: // FIELD_STRING
+			{
+				SetVariantString(inputVariant.StringValue);
+			}
+			case 5: // FIELD_INTEGER
+			{
+				SetVariantInt(inputVariant.IntValue);
+			}
+		}
+	}
+}
+
+static void SF2MapEntity_DoOutputEvent(int entity, int iOutputID, int activator, int caller, SF2MapEntityVariant inputVariant)
+{
+	if (!IsValidEntity(entity))
+		return;
+	
+	SF2MapEntityData entData;
+	if (SF2MapEntityData_Get(entity, entData) == -1)
+		ThrowError("invalid entdata");
+
+	int iOutputIndex = entData.Outputs.FindValue(iOutputID);
+	if (iOutputIndex == -1)
+		return;
+	
+	SF2MapEntityOutputData outputData;
+	entData.Outputs.GetArray(iOutputIndex, outputData, sizeof(outputData));
+
+	// Search by targetname, and if not found, then classname, then invoke AcceptEntityInput with activator + caller arguments.
+	if (outputData.TargetName[0] != '\0')
+	{
+		bool targetFound = false;
+
+		if (!targetFound)
+		{
+			// In I/O land, the searching entity is also the caller, so searchingEntity = caller
+
+			int target = -1;
+			while ((target = SF2MapEntity_FindEntityByTargetname(target, outputData.TargetName, caller, activator, caller)) != -1)
+			{
+				targetFound = true;
+				SF2MapEntity_SetupVariantForInput(outputData.InputParameter, inputVariant);
+				AcceptEntityInput(target, outputData.Input, activator, caller);
+			}
+		}
+
+		if (!targetFound)
+		{
+			int target = INVALID_ENT_REFERENCE;
+			while ((target = FindEntityByClassname(target, outputData.TargetName)) != -1)
+			{
+				targetFound = true;
+
+				SF2MapEntity_SetupVariantForInput(outputData.InputParameter, inputVariant);
+				AcceptEntityInput(target, outputData.Input, activator, caller);
+			}
+		}
+	}
+	
+	int iTimesToFire = outputData.TimesToFire;
+	if (iTimesToFire != -1) 
+	{
+		outputData.TimesToFire--;
+
+		if (iTimesToFire == 0) 
+		{
+			entData.Outputs.Erase(iOutputIndex);
+		}
+		else 
+		{
+			entData.Outputs.SetArray(iOutputIndex, outputData, sizeof(outputData));
+		}
+	}
+}
+
+static void SF2MapEntity_AddOutput(int entity, const char[] szKeyName, const char[] szValue) 
+{
+	if (!IsValidEntity(entity))
+		return;
+	
+	SF2MapEntityData entData;
+	if (SF2MapEntityData_Get(entity, entData) == -1)
+		ThrowError("invalid entdata");
+
+	char sOutputParameters[5][256];
+	int iOutputParamCount = ExplodeString(szValue, ",", sOutputParameters, sizeof(sOutputParameters), sizeof(sOutputParameters[]));
+
+	SF2MapEntityOutputData outputData;
+	outputData.ID = ++entData.OutputIDStamp;
+	outputData.Init();
+
+	SF2MapEntityData_Update(entData);
+
+	strcopy(outputData.Output, sizeof(outputData.Output), szKeyName);
+
+	if (iOutputParamCount >= 1 && sOutputParameters[0][0] != '\0') {
+		strcopy(outputData.TargetName, sizeof(outputData.TargetName), sOutputParameters[0]);
+	}
+
+	if (iOutputParamCount >= 2 && sOutputParameters[1][0] != '\0') {
+		strcopy(outputData.Input, sizeof(outputData.Input), sOutputParameters[1]);
+	}
+
+	if (iOutputParamCount >= 3 && sOutputParameters[2][0] != '\0') {
+		strcopy(outputData.InputParameter, sizeof(outputData.InputParameter), sOutputParameters[2]);
+	}
+
+	if (iOutputParamCount >= 4 && sOutputParameters[3][0] != '\0') {
+		outputData.Delay = StringToFloat(sOutputParameters[3]);
+	}
+
+	if (iOutputParamCount >= 5 && sOutputParameters[4][0] != '\0') {
+		outputData.TimesToFire = StringToInt(sOutputParameters[4]);
+	}
+
+	if (outputData.TimesToFire <= 0 && outputData.TimesToFire != -1)
+	{
+		// Don't add it; it wouldn't fire anyways.
+		return;
+	}
+
+#if defined DEBUG_MAPENTITIES
+
+	PrintToServer("Custom entity %i (%s) registered output:\n - ID: %i\n - Output: %s\n - TargetName: %s\n - Input: %s\n - Input param: %s\n - Delay: %f\n - TimesToFire: %i",
+		EntRefToEntIndex(entData.EntRef), entData.Classname, outputData.ID, outputData.Output, outputData.TargetName, outputData.Input, outputData.InputParameter, outputData.Delay, outputData.TimesToFire);
+
+#endif
+
+	entData.Outputs.PushArray(outputData, sizeof(outputData));
+}
+
+void SF2MapEntity_OnRoundStateChanged(SF2RoundState iRoundState, SF2RoundState iOldRoundState)
+{
+	Call_StartForward(g_CustomEntityOnRoundStateChanged);
+	Call_PushCell(iRoundState);
+	Call_PushCell(iOldRoundState);
+	Call_Finish();
+}
+
+static void SF2MapEntity_OnDifficultyChanged(ConVar cvar, const char[] sOldValue, const char[] sNewValue)
+{
+	int iOldDifficulty = StringToInt(sOldValue);
+	int iDifficulty = StringToInt(sNewValue);
+
+	Call_StartForward(g_CustomEntityOnDifficultyChanged);
+	Call_PushCell(iDifficulty);
+	Call_PushCell(iOldDifficulty);
+	Call_Finish();
+}
+
+void SF2MapEntity_OnPageCountChanged(int iPageCount, int iOldPageCount)
+{
+	Call_StartForward(g_CustomEntityOnPageCountChanged);
+	Call_PushCell(iPageCount);
+	Call_PushCell(iOldPageCount);
+	Call_Finish();
+}
+
+void SF2MapEntity_OnGracePeriodEnd()
+{
+	Call_StartForward(g_CustomEntityOnGracePeriodEnd);
+	Call_Finish();
+}
+
+void SF2MapEntity_OnRenevantWaveTriggered(int iWave)
+{
+	Call_StartForward(g_CustomEntityOnRenevantWaveTriggered);
+	Call_PushCell(iWave);
+	Call_Finish();
+}
+
+void SF2MapEntity_OnEntityDestroyed(int entity) 
+{
+	if (!IsValidEntity(entity))
+		return;
+
+	SF2MapEntityData entData;
+	int iIndex = SF2MapEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_hCustomEntities.Erase(iIndex);
+
+		Call_StartForward(g_CustomEntityOnDestroyed);
+		Call_PushCell(entity);
+		Call_PushString(entData.Classname);
+		Call_Finish();
+
+#if defined DEBUG_MAPENTITIES
+		PrintToServer("Destroyed custom entity %i %s", 
+			EntRefToEntIndex(entData.EntRef), entData.Classname);
+#endif
+	}
+}
+
+void SF2MapEntity_InitGameData(GameData hConfig) 
+{
+	g_hSDKCreateEntityByName = new DynamicDetour(Address_Null, CallConv_CDECL, ReturnType_CBaseEntity, ThisPointer_Ignore);
+	if (!g_hSDKCreateEntityByName)
+		SetFailState("Failed to setup detour for CreateEntityByName");
+	
+	if (!DHookSetFromConf(g_hSDKCreateEntityByName, hConfig, SDKConf_Signature, "CreateEntityByName"))
+		SetFailState("Failed to load CreateEntityByName signature from gamedata");
+	
+	g_hSDKCreateEntityByName.AddParam(HookParamType_CharPtr);
+	g_hSDKCreateEntityByName.AddParam(HookParamType_Int);
+	
+	if (!g_hSDKCreateEntityByName.Enable(Hook_Pre, SF2MapEntity_OnCreateEntityByNamePre))
+		SetFailState("Failed to detour pre-CreateEntityByName.");
+	
+	if (!g_hSDKCreateEntityByName.Enable(Hook_Post, SF2MapEntity_OnCreateEntityByNamePost))
+		SetFailState("Failed to detour post-CreateEntityByName.");
+
+	GameData hSdkToolsConfig = new GameData("sdktools.games");
+	g_hSDKAcceptInput = new DynamicHook(hSdkToolsConfig.GetOffset("AcceptInput"), HookType_Entity, ReturnType_Bool, ThisPointer_CBaseEntity);
+	if (!g_hSDKAcceptInput)
+		SetFailState("Failed to setup hook for CBaseEntity::AcceptInput");
+
+	g_hSDKAcceptInput.AddParam(HookParamType_CharPtr);
+	g_hSDKAcceptInput.AddParam(HookParamType_CBaseEntity);
+	g_hSDKAcceptInput.AddParam(HookParamType_CBaseEntity);
+	g_hSDKAcceptInput.AddParam(HookParamType_Object, 20); // SIZEOF_VARIANT_T
+	g_hSDKAcceptInput.AddParam(HookParamType_Int);
+
+	delete hSdkToolsConfig;
+
+	g_hSDKKeyValue = new DynamicHook(hConfig.GetOffset("CBaseEntity::KeyValue"), HookType_Entity, ReturnType_Bool, ThisPointer_CBaseEntity);
+	if (!g_hSDKKeyValue)
+		SetFailState("Failed to setup hook for CBaseEntity::KeyValue");
+
+	g_hSDKKeyValue.AddParam(HookParamType_CharPtr);
+	g_hSDKKeyValue.AddParam(HookParamType_CharPtr);
+
+	StartPrepSDKCall(SDKCall_Entity);
+	PrepSDKCall_SetFromConf(hConfig, SDKConf_Virtual, "CBaseTrigger::PassesTriggerFilters");
+	PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer);
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+	if ((g_hSDKPassesTriggerFilters = EndPrepSDKCall()) == INVALID_HANDLE)
+		SetFailState("Failed to setup CBaseTrigger::PassesTriggerFilters call from gamedata!");
+}
+
+#undef DEBUG_MAPENTITIES

--- a/addons/sourcemod/scripting/sf2/entities/base.sp
+++ b/addons/sourcemod/scripting/sf2/entities/base.sp
@@ -1,0 +1,145 @@
+// base
+
+// Not an actual entity; use this as a template for creating new entities.
+// Replace "SF2MapEntityBase" with the identifier you want.
+
+// To initialize, call the SF2MapEntityBase_Initialize() function from SF2MapEntity_Initialize().
+
+static const char g_sEntityClassname[] = ""; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = ""; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+/**
+ *	Internal data stored for the entity.
+ */
+enum struct SF2MapEntityBaseData
+{
+	int EntRef;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+	}
+
+	void Destroy()
+	{
+	}
+}
+
+/**
+ *	Interface that exposes public methods for interacting with the entity.
+ */
+methodmap SF2MapEntityBase < SF2MapEntity
+{
+	public SF2MapEntityBase(int entIndex) { return view_as<SF2MapEntityBase>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2MapEntityBaseData entData;
+		return (SF2MapEntityBaseData_Get(this.EntRef, entData) != -1);
+	}
+}
+
+void SF2MapEntityBase_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2MapEntityBaseData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2MapEntityBase_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2MapEntityBase_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2MapEntityBase_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2MapEntityBase_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2MapEntityBase_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2MapEntityBase_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2MapEntityBase_OnMapStart);
+}
+
+static void SF2MapEntityBase_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2MapEntityBase_OnMapStart() 
+{
+}
+
+static void SF2MapEntityBase_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2MapEntityBaseData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2MapEntityBase_SpawnPost);
+}
+
+static Action SF2MapEntityBase_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static Action SF2MapEntityBase_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static void SF2MapEntityBase_SpawnPost(int entity) 
+{
+}
+
+static void SF2MapEntityBase_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2MapEntityBaseData entData;
+	int iIndex = SF2MapEntityBaseData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2MapEntityBase_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2MapEntityBaseData_Get(int entIndex, SF2MapEntityBaseData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+static int SF2MapEntityBaseData_Update(SF2MapEntityBaseData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}

--- a/addons/sourcemod/scripting/sf2/entities/sf2_game_text.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_game_text.sp
@@ -1,0 +1,103 @@
+// sf2_game_text
+// This is a specialized game_text entity that allows maps to show text to only RED
+// while utilizing SF2's HudSync object, the same that is used by intro/page/escape messages.
+
+// Normally, game_text entities' messages get immediately replaced in-game due to the
+// constant displaying of HUD text by SF2, rendering the text unreadable and useless.
+
+static const char g_sEntityClassname[] = "sf2_game_text";
+static const char g_sEntityTranslatedClassname[] = "game_text";
+
+void SF2GameTextEntity_Initialize() 
+{
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2GameTextEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2GameTextEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2GameTextEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2GameTextEntity_OnMapStart);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2GameTextEntity_OnEntityDestroyed);
+}
+
+static void SF2GameTextEntity_OnMapStart() 
+{
+}
+
+static void SF2GameTextEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SDKHook(entity, SDKHook_SpawnPost, SF2GameTextEntity_SpawnPost);
+}
+
+static Action SF2GameTextEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	if (strcmp(szInputName, "display", false) == 0)
+	{
+		int iClients[MAXPLAYERS + 1];
+		int iClientsNum;
+		
+		char sMessage[512];
+		GetEntPropString(entity, Prop_Data, "m_iszMessage", sMessage, sizeof(sMessage));
+
+		char sVariant[PLATFORM_MAX_PATH];
+		SF2MapEntity_GetVariantString(sVariant, sizeof(sVariant));
+
+		if (sVariant[0] != '\0')
+		{
+			// If a targetname is specified, try to show text to the matched entity.
+
+			int target = -1;
+			while ((target = SF2MapEntity_FindEntityByTargetname(target, sVariant, caller, activator, caller)) != -1)
+			{
+				if (IsValidClient(target))
+				{
+					iClients[iClientsNum++] = target;
+				}
+			}
+		}
+		else 
+		{
+			int iSpawnFlags = GetEntProp(entity, Prop_Data, "m_spawnflags");
+
+			for (int i = 1; i <= MaxClients; i++)
+			{
+				if (!IsClientInGame(i)) continue;
+				
+				// If 'All Players' not set, only show message to RED.
+				if ((iSpawnFlags & 1) == 0 && g_bPlayerEliminated[i] && !IsClientInGhostMode(i))
+					continue;
+
+				iClients[iClientsNum++] = i;
+			}
+		}
+
+		ShowHudTextUsingTextEntity(iClients, iClientsNum, entity, g_hHudSync, sMessage);
+
+		return Plugin_Handled;
+	}
+	
+	return Plugin_Continue;
+}
+
+static void SF2GameTextEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+}
+
+static void SF2GameTextEntity_SpawnPost(int entity) 
+{
+	// PrintToServer("Spawned sf2_game_text entity! entity: %i", entity);
+}
+
+static Action SF2GameTextEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}

--- a/addons/sourcemod/scripting/sf2/entities/sf2_gamerules.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_gamerules.sp
@@ -1,0 +1,776 @@
+// sf2_gamerules
+
+static const char g_sEntityClassname[] = "sf2_gamerules";
+static const char g_sEntityTranslatedClassname[] = "info_target";
+
+static ArrayList g_EntityData;
+
+enum struct SF2GamerulesEntityData
+{
+	int EntRef;
+
+	/*
+		Round Start Keyvalues
+
+		These are keyvalues that are read only once at round start.
+		If you want to dynamically change these values mid-round, use the inputs instead.
+	*/
+	char BossName[SF2_MAX_PROFILE_NAME_LENGTH];
+	int MaxPlayers;
+	int MaxPages;
+	int InitialTimeLimit;
+	int PageCollectAddTime;
+	char PageCollectSoundPath[PLATFORM_MAX_PATH];
+	bool HasEscapeObjective;
+	int EscapeTimeLimit;
+	bool StopPageMusicOnEscape;
+	bool Survive;
+	int SurviveUntilTime;
+	bool InfiniteFlashlight;
+	bool InfiniteSprint;
+	bool InfiniteBlink;
+	bool BossesChaseEndlessly;
+
+	char IntroMusicPath[PLATFORM_MAX_PATH];
+	int IntroFadeColor[4];
+	float IntroFadeHoldTime;
+	float IntroFadeTime;
+
+	void Init(int entIndex) 
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+
+		// Default values should be the same as specified in InitializeMapEntities()
+		// at the fallback of having no gamerules entity present.
+
+		g_cvBossMain.GetString(this.BossName, SF2_MAX_PROFILE_NAME_LENGTH);
+
+		this.MaxPlayers = 8;
+		this.MaxPages = 1;
+
+		this.InitialTimeLimit = g_cvTimeLimit.IntValue;
+		this.PageCollectAddTime = g_cvTimeGainFromPageGrab.IntValue;
+		strcopy(this.PageCollectSoundPath, PLATFORM_MAX_PATH, PAGE_GRABSOUND);
+
+		this.HasEscapeObjective = false;
+		this.EscapeTimeLimit = g_cvTimeLimitEscape.IntValue;
+		this.StopPageMusicOnEscape = false;
+		this.Survive = false;
+		this.SurviveUntilTime = g_cvTimeEscapeSurvival.IntValue;
+
+		this.InfiniteFlashlight = false;
+		this.InfiniteSprint = false;
+		this.InfiniteBlink = false;
+
+		this.BossesChaseEndlessly = false;
+
+		strcopy(this.IntroMusicPath, PLATFORM_MAX_PATH, SF2_INTRO_DEFAULT_MUSIC);
+		this.IntroFadeColor[0] = 0; this.IntroFadeColor[1] = 0; this.IntroFadeColor[2] = 0; this.IntroFadeColor[3] = 255;
+		this.IntroFadeHoldTime = g_cvIntroDefaultHoldTime.FloatValue;
+		this.IntroFadeTime = g_cvIntroDefaultFadeTime.FloatValue;
+	}
+
+	void SetBossName(const char[] sBossName)
+	{
+		strcopy(this.BossName, SF2_MAX_PROFILE_NAME_LENGTH, sBossName);
+	}
+
+	void SetPageCollectSoundPath(const char[] sPath)
+	{
+		strcopy(this.PageCollectSoundPath, PLATFORM_MAX_PATH, sPath);
+	}
+
+	void SetIntroMusicPath(const char[] sPath)
+	{
+		strcopy(this.IntroMusicPath, PLATFORM_MAX_PATH, sPath);
+	}
+
+	void SetIntroMusicColor(const iColor[4])
+	{
+		for (int i = 0; i < 4; i++) this.IntroFadeColor[i] = iColor[i];
+	}
+}
+
+methodmap SF2GamerulesEntity < SF2MapEntity
+{
+	public SF2GamerulesEntity(int entIndex)
+	{
+		return view_as<SF2GamerulesEntity>(SF2MapEntity(entIndex));
+	}
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2GamerulesEntityData entData;
+		return (SF2GamerulesEntityData_Get(this.EntRef, entData) != -1);
+	}
+
+	property int MaxPlayers
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.MaxPlayers;
+		}
+	}
+
+	property int MaxPages
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.MaxPages;
+		}
+	}
+
+	property int InitialTimeLimit
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.InitialTimeLimit;
+		}
+	}
+
+	property int PageCollectAddTime
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.PageCollectAddTime;
+		}
+	}
+
+	public void GetPageCollectSoundPath(char[] sBuffer, int iBufferLen)
+	{
+		SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData);
+		strcopy(sBuffer, iBufferLen, entData.PageCollectSoundPath);
+	}
+
+	property bool InfiniteFlashlight
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.InfiniteFlashlight;
+		}
+	}
+
+	property bool InfiniteSprint
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.InfiniteSprint;
+		}
+	}
+
+	property bool InfiniteBlink
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.InfiniteBlink;
+		}
+	}
+
+	property bool BossesChaseEndlessly
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.BossesChaseEndlessly;
+		}
+	}
+
+	property bool HasEscapeObjective
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.HasEscapeObjective;
+		}
+	}
+
+	property int EscapeTimeLimit
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.EscapeTimeLimit;
+		}
+	}
+
+	property bool StopPageMusicOnEscape
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.StopPageMusicOnEscape;
+		}
+	}
+
+	property bool Survive
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.Survive;
+		}
+	}
+
+	property int SurviveUntilTime
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.SurviveUntilTime;
+		}
+	}
+
+	public void GetBossName(char[] sBuffer, int iBufferLen)
+	{
+		SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData);
+		strcopy(sBuffer, iBufferLen, entData.BossName);
+	}
+
+	public void GetIntroMusicPath(char[] sBuffer, int iBufferLen)
+	{
+		SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData);
+		strcopy(sBuffer, iBufferLen, entData.IntroMusicPath);
+	}
+
+	public void GetIntroFadeColor(int iBuffer[4])
+	{
+		SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData);
+		for (int i = 0; i < 4; i++) iBuffer[i] = entData.IntroFadeColor[i]; 
+	}
+
+	property float IntroFadeHoldTime
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.IntroFadeHoldTime;
+		}
+	}
+
+	property float IntroFadeTime
+	{
+		public get() 
+		{
+			SF2GamerulesEntityData entData; SF2GamerulesEntityData_Get(this.EntRef, entData); return entData.IntroFadeTime;
+		}
+	}
+}
+
+SF2GamerulesEntity FindSF2GamerulesEntity()
+{
+	return SF2GamerulesEntity(FindEntityByClassname(-1, g_sEntityClassname));
+}
+
+void SF2GamerulesEntity_Initialize()
+{
+	g_EntityData = new ArrayList(sizeof(SF2GamerulesEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2GamerulesEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2GamerulesEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2GamerulesEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2GamerulesEntity_OnMapStart);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2GamerulesEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2GamerulesEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2GamerulesEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnRoundStateChanged, SF2GamerulesEntity_OnRoundStateChanged);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnGracePeriodEnd, SF2GameRulesEntity_OnGracePeriodEnd);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnDifficultyChanged, SF2GameRulesEntity_OnDifficultyChanged);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnPageCountChanged, SF2GameRulesEntity_OnPageCountChanged);
+}
+
+static void SF2GamerulesEntity_OnLevelInit(const char[] sMapName) 
+{
+	g_EntityData.Clear();
+}
+
+static void SF2GamerulesEntity_OnMapStart() 
+{
+	if (g_EntityData.Length > 1) 
+	{
+		LogSF2Message("WARNING! There are multiple %s entities in the map!!", g_sEntityClassname);
+	}
+}
+
+static void SF2GamerulesEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2GamerulesEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2GamerulesEntity_SpawnPost);
+}
+
+static Action SF2GamerulesEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2GamerulesEntityData entData;
+	SF2GamerulesEntityData_Get(entity, entData);
+
+	SF2GamerulesEntity gameRules = SF2GamerulesEntity(entity);
+
+	if (strcmp(szKeyName, "boss", false) == 0)
+	{
+		entData.SetBossName(szValue);
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "maxplayers", false) == 0)
+	{
+		int iMaxPlayers = StringToInt(szValue);
+		if (iMaxPlayers < 1) iMaxPlayers = 1;
+		else if (iMaxPlayers > MaxClients) iMaxPlayers = MaxClients;
+		
+		entData.MaxPlayers = iMaxPlayers;
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "maxpages", false) == 0)
+	{
+		int iPageCount = StringToInt(szValue);
+		if (iPageCount < 0) iPageCount = 0;
+
+		entData.MaxPages = iPageCount;
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "initialtimelimit", false) == 0) 
+	{
+		int iRoundTimeLimit = StringToInt(szValue);
+		if (iRoundTimeLimit < 0) iRoundTimeLimit = 0;
+
+		entData.InitialTimeLimit = iRoundTimeLimit;
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "pagecollectaddtime", false) == 0) 
+	{
+		int iPageCollectAddTime = StringToInt(szValue);
+
+		entData.PageCollectAddTime = iPageCollectAddTime;
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "pagecollectsound", false) == 0)
+	{
+		entData.SetPageCollectSoundPath(szValue);
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "escape", false) == 0) 
+	{
+		entData.HasEscapeObjective = StringToInt(szValue) != 0;
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "escapetime", false) == 0) 
+	{
+		entData.EscapeTimeLimit = StringToInt(szValue);
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "stoppagemusiconescape", false) == 0) 
+	{
+		entData.StopPageMusicOnEscape = StringToInt(szValue) != 0;
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "survive", false) == 0) 
+	{
+		entData.Survive = StringToInt(szValue) != 0;
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "surviveuntiltime", false) == 0) 
+	{
+		entData.SurviveUntilTime = StringToInt(szValue);
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "bosseschaseendlessly", false) == 0) 
+	{
+		entData.BossesChaseEndlessly = StringToInt(szValue) != 0;
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "infiniteflashlight", false) == 0) 
+	{
+		entData.InfiniteFlashlight = StringToInt(szValue) != 0;
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "infinitesprint", false) == 0)
+	{
+		entData.InfiniteSprint = StringToInt(szValue) != 0;
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "infiniteblink", false) == 0)
+	{
+		entData.InfiniteBlink = StringToInt(szValue) != 0;
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "intromusicpath", false) == 0)
+	{
+		entData.SetIntroMusicPath(szValue);
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "introfadecolor", false) == 0)
+	{
+		char sTokens[4][16];
+		int iNumTokens = ExplodeString(szValue, " ", sTokens, 4, 16);
+
+		int iColor[4] = { 0, 0, 0, 255 };
+		for (int i = 0; i < iNumTokens && i < 4; i++) {
+			int colorVal = StringToInt(sTokens[i]);
+			if (colorVal < 0) colorVal = 0;
+			else if (colorVal > 255) colorVal = 255;
+			
+			iColor[i] = colorVal;
+		}
+
+		entData.SetIntroMusicColor(iColor);
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "introfadeholdtime", false) == 0)
+	{
+		entData.IntroFadeHoldTime = StringToFloat(szValue);
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "introfadetime", false) == 0)
+	{
+		entData.IntroFadeTime = StringToFloat(szValue);
+		SF2GamerulesEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "OnGracePeriodEnded", false) == 0 ||
+				strcmp(szKeyName, "OnDifficultyChanged", false) == 0 ||
+				strcmp(szKeyName, "OnStateEnterWaiting", false) == 0 ||
+				strcmp(szKeyName, "OnStateExitWaiting", false) == 0 ||
+				strcmp(szKeyName, "OnStateEnterIntro", false) == 0 ||
+				strcmp(szKeyName, "OnStateExitIntro", false) == 0 ||
+				strcmp(szKeyName, "OnStateEnterActive", false) == 0 ||
+				strcmp(szKeyName, "OnStateExitActive", false) == 0 ||
+				strcmp(szKeyName, "OnStateEnterEscape", false) == 0 ||
+				strcmp(szKeyName, "OnStateExitEscape", false) == 0 ||
+				strcmp(szKeyName, "OnStateEnterOutro", false) == 0 ||
+				strcmp(szKeyName, "OnStateExitOutro", false) == 0 ||
+				strcmp(szKeyName, "OnCollectedPagesChanged", false) == 0 ||
+				strcmp(szKeyName, "OnSurvivalComplete", false) == 0) 
+	{
+		gameRules.AddOutput(szKeyName, szValue);
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static Action SF2GamerulesEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	if (strcmp(szInputName, "SetTimeLimit", false) == 0) 
+	{
+		int iRoundTimeLimit = SF2MapEntity_GetIntFromVariant();
+		if (iRoundTimeLimit < 0)
+			iRoundTimeLimit = 0;
+
+		g_iRoundTimeLimit = iRoundTimeLimit;
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetEscapeTimeLimit", false) == 0)
+	{
+		int iEscapeTimeLimit = SF2MapEntity_GetIntFromVariant();
+		if (iEscapeTimeLimit < 0)
+			iEscapeTimeLimit = 0;
+
+		g_iRoundEscapeTimeLimit = iEscapeTimeLimit;
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetTime", false) == 0) 
+	{
+		int iRoundTime = SF2MapEntity_GetIntFromVariant();
+		if (iRoundTime < 0) iRoundTime = 0;
+
+		SetRoundTime(iRoundTime);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetTimeToAddOnCollectPage", false) == 0) 
+	{
+		g_iRoundTimeGainFromPage = SF2MapEntity_GetIntFromVariant();
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetCollectedPages", false) == 0)
+	{
+		int iPagesCollected = SF2MapEntity_GetIntFromVariant();
+		if (iPagesCollected < 0) iPagesCollected = 0;
+
+		SetPageCount(iPagesCollected);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "AddCollectedPages", false) == 0)
+	{
+		int iPagesCollected = g_iPageCount + SF2MapEntity_GetIntFromVariant();
+		if (iPagesCollected < 0) iPagesCollected = 0;
+		
+		SetPageCount(iPagesCollected);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SubtractCollectedPages", false) == 0)
+	{
+		int iPagesCollected = g_iPageCount - SF2MapEntity_GetIntFromVariant();
+		if (iPagesCollected < 0) iPagesCollected = 0;
+		
+		SetPageCount(iPagesCollected);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "EnableInfiniteFlashlight", false) == 0) 
+	{
+		g_bRoundInfiniteFlashlight = true;
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "DisableInfiniteFlashlight", false) == 0) 
+	{
+		g_bRoundInfiniteFlashlight = false;
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "EnableInfiniteSprint", false) == 0) 
+	{
+		g_bRoundInfiniteSprint = true;
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "DisableInfiniteSprint", false) == 0) 
+	{
+		g_bRoundInfiniteSprint = false;
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "EnableInfiniteBlink", false) == 0) 
+	{
+		g_bRoundInfiniteBlink = true;
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "DisableInfiniteBlink", false) == 0) 
+	{
+		g_bRoundInfiniteBlink = false;
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetBoss", false) == 0) 
+	{
+		char sVariant[SF2_MAX_PROFILE_NAME_LENGTH];
+		SF2MapEntity_GetVariantString(sVariant, sizeof(sVariant));
+
+		g_cvBossMain.SetString(sVariant);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetBossOverride", false) == 0) 
+	{
+		char sVariant[SF2_MAX_PROFILE_NAME_LENGTH];
+		SF2MapEntity_GetVariantString(sVariant, sizeof(sVariant));
+
+		g_cvBossProfileOverride.SetString(sVariant);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "ClearBossOverride", false) == 0) 
+	{
+		g_cvBossProfileOverride.SetString("");
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetDifficulty", false) == 0) 
+	{
+		int iDifficulty = SF2MapEntity_GetIntFromVariant();
+		if (iDifficulty < 0) iDifficulty = 0;
+		else if (iDifficulty >= Difficulty_Max) iDifficulty = Difficulty_Max - 1;
+
+		g_cvDifficulty.SetInt(iDifficulty);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "EnableBossesChaseEndlessly", false) == 0)
+	{
+		g_bBossesChaseEndlessly = true;
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "DisableBossesChaseEndlessly", false) == 0)
+	{
+		g_bBossesChaseEndlessly = false;
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "EndGracePeriod", false) == 0)
+	{
+		if (g_bRoundGrace && g_hRoundGraceTimer != INVALID_HANDLE) 
+			TriggerTimer(g_hRoundGraceTimer);
+		
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static void SF2GamerulesEntity_SpawnPost(int entity) 
+{
+}
+
+static void SF2GamerulesEntity_OnRoundStateChanged(SF2RoundState iRoundState, SF2RoundState iOldRoundState)
+{
+	for (int i = 0; i < g_EntityData.Length; i++) 
+	{
+		SF2GamerulesEntityData entData;
+		g_EntityData.GetArray(i, entData, sizeof(entData));
+
+		if (!IsValidEntity(entData.EntRef))
+			continue;
+
+		SF2GamerulesEntity gameRules = SF2GamerulesEntity(entData.EntRef);
+		SF2MapEntityVariant inputVariant;
+		inputVariant.Init();
+
+		switch (iOldRoundState)
+		{
+			case SF2RoundState_Waiting:
+				gameRules.FireOutput("OnStateExitWaiting", -1, entData.EntRef, inputVariant);
+			case SF2RoundState_Intro:
+				gameRules.FireOutput("OnStateExitIntro", -1, entData.EntRef, inputVariant);
+			case SF2RoundState_Active:
+				gameRules.FireOutput("OnStateExitActive", -1, entData.EntRef, inputVariant);
+			case SF2RoundState_Escape:
+				gameRules.FireOutput("OnStateExitEscape", -1, entData.EntRef, inputVariant);
+			case SF2RoundState_Outro:
+				gameRules.FireOutput("OnStateExitOutro", -1, entData.EntRef, inputVariant);
+		}
+
+		switch (iRoundState)
+		{
+			case SF2RoundState_Waiting:
+				gameRules.FireOutput("OnStateEnterWaiting", -1, entData.EntRef, inputVariant);
+			case SF2RoundState_Intro:
+				gameRules.FireOutput("OnStateEnterIntro", -1, entData.EntRef, inputVariant);
+			case SF2RoundState_Active:
+				gameRules.FireOutput("OnStateEnterActive", -1, entData.EntRef, inputVariant);
+			case SF2RoundState_Escape:
+				gameRules.FireOutput("OnStateEnterEscape", -1, entData.EntRef, inputVariant);
+			case SF2RoundState_Outro:
+				gameRules.FireOutput("OnStateEnterOutro", -1, entData.EntRef, inputVariant);
+		}
+	}
+}
+
+static void SF2GameRulesEntity_OnPageCountChanged(int iPageCount, int iOldPageCount)
+{
+	for (int i = 0; i < g_EntityData.Length; i++) 
+	{
+		SF2GamerulesEntityData entData;
+		g_EntityData.GetArray(i, entData, sizeof(entData));
+
+		if (!IsValidEntity(entData.EntRef))
+			continue;
+		
+		SF2MapEntityVariant inputVariant;
+		inputVariant.Init();
+		inputVariant.SetInt(iPageCount);
+		SF2GamerulesEntity(entData.EntRef).FireOutput("OnCollectedPagesChanged", -1, entData.EntRef, inputVariant);
+	}
+}
+
+static void SF2GameRulesEntity_OnGracePeriodEnd()
+{
+	for (int i = 0; i < g_EntityData.Length; i++) 
+	{
+		SF2GamerulesEntityData entData;
+		g_EntityData.GetArray(i, entData, sizeof(entData));
+
+		if (!IsValidEntity(entData.EntRef))
+			continue;
+		
+		SF2GamerulesEntity(entData.EntRef).FireOutputNoVariant("OnGracePeriodEnded", -1, entData.EntRef);
+	}
+}
+
+static void SF2GameRulesEntity_OnDifficultyChanged(int iDifficulty, int iOldDifficulty)
+{
+	for (int i = 0; i < g_EntityData.Length; i++) 
+	{
+		SF2GamerulesEntityData entData;
+		g_EntityData.GetArray(i, entData, sizeof(entData));
+
+		if (!IsValidEntity(entData.EntRef))
+			continue;
+		
+		SF2MapEntityVariant inputVariant;
+		inputVariant.Init();
+		inputVariant.SetInt(iDifficulty);
+		SF2GamerulesEntity(entData.EntRef).FireOutput("OnDifficultyChanged", -1, entData.EntRef, inputVariant);
+	}
+}
+
+static void SF2GamerulesEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2GamerulesEntityData entData;
+	int iIndex = SF2GamerulesEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2GamerulesEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2GamerulesEntityData_Get(int entIndex, SF2GamerulesEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+static int SF2GamerulesEntityData_Update(SF2GamerulesEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}

--- a/addons/sourcemod/scripting/sf2/entities/sf2_info_boss_spawn.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_info_boss_spawn.sp
@@ -1,0 +1,249 @@
+// sf2_info_boss_spawn
+
+static const char g_sEntityClassname[] = "sf2_info_boss_spawn"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "info_target"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+/**
+ *	Internal data stored for the entity.
+ */
+enum struct SF2BossSpawnEntityData
+{
+	int EntRef;
+	char BossProfile[SF2_MAX_PROFILE_NAME_LENGTH];
+	int MaxBosses;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+		this.BossProfile[0] = '\0';
+		this.MaxBosses = 1;
+	}
+
+	void Destroy()
+	{
+	}
+
+	void SetBossProfile(const char[] sProfile)
+	{
+		strcopy(this.BossProfile, SF2_MAX_PROFILE_NAME_LENGTH, sProfile);
+	}
+}
+
+/**
+ *	Interface that exposes public methods for interacting with the entity.
+ */
+methodmap SF2BossSpawnEntity < SF2MapEntity
+{
+	public SF2BossSpawnEntity(int entIndex) { return view_as<SF2BossSpawnEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2BossSpawnEntityData entData;
+		return (SF2BossSpawnEntityData_Get(this.EntRef, entData) != -1);
+	}
+
+	public void GetBossProfile(char[] sBuffer, int iBufferLen)
+	{
+		SF2BossSpawnEntityData entData; SF2BossSpawnEntityData_Get(this.EntRef, entData); 
+		strcopy(sBuffer, iBufferLen, entData.BossProfile);
+	}
+
+	property int MaxBosses
+	{
+		public get() { SF2BossSpawnEntityData entData; SF2BossSpawnEntityData_Get(this.EntRef, entData); return entData.MaxBosses; }
+	}
+
+	public void Spawn()
+	{
+		char sTargetProfile[SF2_MAX_PROFILE_NAME_LENGTH];
+		this.GetBossProfile(sTargetProfile, sizeof(sTargetProfile));
+		if (sTargetProfile[0] == '\0')
+		{
+			PrintToServer("%s tried to spawn with blank profile", g_sEntityClassname);
+			return;
+		}
+
+		char sProfile[SF2_MAX_PROFILE_NAME_LENGTH];
+
+		float flPos[3];
+		GetEntPropVector(this.EntRef, Prop_Data, "m_vecOrigin", flPos);
+
+		int iCount = 0;
+		int iMaxCount = this.MaxBosses;
+
+		for (int iBossIndex = 0; iBossIndex < MAX_BOSSES && iCount < iMaxCount; iBossIndex++)
+		{
+			if (!NPCIsValid(iBossIndex))
+				continue;
+
+			NPCGetProfile(iBossIndex, sProfile, sizeof(sProfile));
+			if (strcmp(sProfile, sTargetProfile) == 0)
+			{
+				SpawnSlender(view_as<SF2NPC_BaseNPC>(iBossIndex), flPos);
+				iCount++;
+
+				this.FireOutputNoVariant("OnSpawn", NPCGetEntIndex(iBossIndex), this.EntRef);
+			}
+		}
+	}
+}
+
+void SF2BossSpawnEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2BossSpawnEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2BossSpawnEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2BossSpawnEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2BossSpawnEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2BossSpawnEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2BossSpawnEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2BossSpawnEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2BossSpawnEntity_OnMapStart);
+}
+
+static void SF2BossSpawnEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2BossSpawnEntity_OnMapStart() 
+{
+}
+
+static void SF2BossSpawnEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2BossSpawnEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2BossSpawnEntity_SpawnPost);
+}
+
+static Action SF2BossSpawnEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2BossSpawnEntityData entData;
+	int iIndex = SF2BossSpawnEntityData_Get(entity, entData);
+	if (iIndex == -1)
+		return Plugin_Continue;
+	
+	SF2BossSpawnEntity spawnPoint = SF2BossSpawnEntity(entity);
+
+	if (strcmp(szKeyName, "profile", false) == 0)
+	{
+		entData.SetBossProfile(szValue);
+		SF2BossSpawnEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "max", false) == 0)
+	{
+		int iValue = StringToInt(szValue);
+		if (iValue < 0)
+			iValue = 0;
+
+		entData.MaxBosses = iValue;
+		SF2BossSpawnEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "OnSpawn", false) == 0)
+	{
+		spawnPoint.AddOutput(szKeyName, szValue);
+
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static Action SF2BossSpawnEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2BossSpawnEntityData entData;
+	int iIndex = SF2BossSpawnEntityData_Get(entity, entData);
+	if (iIndex == -1)
+		return Plugin_Continue;
+	
+	SF2BossSpawnEntity spawnPoint = SF2BossSpawnEntity(entity);
+
+	if (strcmp(szInputName, "Spawn", false) == 0)
+	{
+		spawnPoint.Spawn();
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetBossProfile", false) == 0)
+	{
+		char sProfile[SF2_MAX_PROFILE_NAME_LENGTH];
+		SF2MapEntity_GetStringFromVariant(sProfile, sizeof(sProfile));
+
+		entData.SetBossProfile(sProfile);
+		SF2BossSpawnEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static void SF2BossSpawnEntity_SpawnPost(int entity) 
+{
+}
+
+static void SF2BossSpawnEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2BossSpawnEntityData entData;
+	int iIndex = SF2BossSpawnEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2BossSpawnEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2BossSpawnEntityData_Get(int entIndex, SF2BossSpawnEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+static int SF2BossSpawnEntityData_Update(SF2BossSpawnEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}

--- a/addons/sourcemod/scripting/sf2/entities/sf2_info_page_music.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_info_page_music.sp
@@ -1,0 +1,341 @@
+// base
+
+// Not an actual entity; use this as a template for creating new entities.
+// Replace "SF2PageMusicEntity" with the identifier you want.
+
+// To initialize, call the SF2PageMusicEntity_Initialize() function from SF2MapEntity_Initialize().
+
+static const char g_sEntityClassname[] = "sf2_info_page_music"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "info_target"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+#define SF2MAPENTITES_PAGE_MUSIC_MAXRANGES 16
+
+enum struct SF2PageMusicEntityRangeData
+{
+	int Min;
+	int Max;
+	char Music[PLATFORM_MAX_PATH];
+}
+
+/**
+ *	Internal data stored for the entity.
+ */
+enum struct SF2PageMusicEntityData
+{
+	int EntRef;
+	ArrayList Ranges;
+	bool Layered;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+		this.Ranges = new ArrayList(sizeof(SF2PageMusicEntityRangeData));
+		this.Ranges.Resize(SF2MAPENTITES_PAGE_MUSIC_MAXRANGES);
+		this.Layered = false;
+
+		SF2PageMusicEntityRangeData rangeData;
+
+		for (int i = 0; i < this.Ranges.Length; i++)
+		{
+			this.Ranges.GetArray(i, rangeData, sizeof(rangeData));
+			rangeData.Min = 0;
+			rangeData.Max = 0;
+			rangeData.Music[0] = '\0';
+			this.Ranges.SetArray(i, rangeData, sizeof(rangeData));
+		}
+	}
+
+	void GetRange(int index, SF2PageMusicEntityRangeData rangeData)
+	{
+		this.Ranges.GetArray(index, rangeData, sizeof(rangeData));
+	}
+
+	void SetRange(int index, SF2PageMusicEntityRangeData rangeData)
+	{
+		this.Ranges.SetArray(index, rangeData, sizeof(rangeData));
+	}
+
+	bool IsRangeSet(int index)
+	{
+		SF2PageMusicEntityRangeData rangeData;
+		this.GetRange(index, rangeData);
+		return rangeData.Music[0] != '\0';
+	}
+
+	bool GetRangeMusic(int num, char[] sBuffer, int iBufferLen)
+	{
+		SF2PageMusicEntityRangeData rangeData;
+
+		for (int i = 0; i < this.Ranges.Length; i++)
+		{
+			if (!this.IsRangeSet(i))
+				continue;
+
+			this.GetRange(i, rangeData);
+			if (num >= rangeData.Min && num <= rangeData.Max)
+			{
+				strcopy(sBuffer, iBufferLen, rangeData.Music);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	bool GetRangeBounds(int num, int &min, int &max)
+	{
+		SF2PageMusicEntityRangeData rangeData;
+
+		for (int i = 0; i < this.Ranges.Length; i++)
+		{
+			if (!this.IsRangeSet(i))
+				continue;
+
+			this.GetRange(i, rangeData);
+			if (num >= rangeData.Min && num <= rangeData.Max)
+			{
+				min = rangeData.Min;
+				max = rangeData.Max;
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	void Destroy()
+	{
+		if (this.Ranges != null)
+			delete this.Ranges;
+	}
+}
+
+/**
+ *	Interface that exposes public methods for interacting with the entity.
+ */
+methodmap SF2PageMusicEntity < SF2MapEntity
+{
+	public SF2PageMusicEntity(int entIndex) { return view_as<SF2PageMusicEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2PageMusicEntityData entData;
+		return (SF2PageMusicEntityData_Get(this.EntRef, entData) != -1);
+	}
+
+	property bool Layered
+	{
+		public get() { SF2PageMusicEntityData entData; SF2PageMusicEntityData_Get(this.EntRef, entData); return entData.Layered; }
+	}
+
+	public bool GetRangeMusic(int num, char[] sBuffer, int iBufferLen)
+	{
+		SF2PageMusicEntityData entData; SF2PageMusicEntityData_Get(this.EntRef, entData);
+		return entData.GetRangeMusic(num, sBuffer, iBufferLen);
+	}
+
+	public bool GetRangeBounds(int num, int &min, int &max)
+	{
+		SF2PageMusicEntityData entData; SF2PageMusicEntityData_Get(this.EntRef, entData);
+		return entData.GetRangeBounds(num, min, max);
+	}
+
+	public void InsertRanges(ArrayList hRanges)
+	{
+		SF2PageMusicEntityData entData; SF2PageMusicEntityData_Get(this.EntRef, entData);
+		SF2PageMusicEntityRangeData rangeData;
+
+		for (int i = 0; i < entData.Ranges.Length; i++)
+		{
+			entData.GetRange(i, rangeData);
+			if (rangeData.Music[0] != '\0')
+			{
+				int index = hRanges.Push(this.EntRef);
+				hRanges.Set(index, rangeData.Min, 1);
+				hRanges.Set(index, rangeData.Max, 2);
+			}
+		}
+	}
+}
+
+void SF2PageMusicEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2PageMusicEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2PageMusicEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2PageMusicEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2PageMusicEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2PageMusicEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2PageMusicEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PageMusicEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PageMusicEntity_OnMapStart);
+}
+
+static void SF2PageMusicEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2PageMusicEntity_OnMapStart() 
+{
+}
+
+static void SF2PageMusicEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2PageMusicEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2PageMusicEntity_SpawnPost);
+}
+
+static Action SF2PageMusicEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2PageMusicEntityData entData;
+	if (SF2PageMusicEntityData_Get(entity, entData) == -1)
+		return Plugin_Continue;
+	
+	if (StrContains(szKeyName, "range", false) == 0)
+	{
+		if (szValue[0] == '\0')
+			return Plugin_Continue;
+
+		char sBuffer[256];
+		strcopy(sBuffer, sizeof(sBuffer), szKeyName);
+		ReplaceStringEx(sBuffer, sizeof(sBuffer), "range", "", _, _, false);
+		
+		int rangeId = StringToInt(sBuffer) - 1;
+		if (rangeId < 0 || rangeId >= SF2MAPENTITES_PAGE_MUSIC_MAXRANGES)
+			return Plugin_Continue;
+
+		char sTokens[2][16];
+		int iNumTokens = ExplodeString(szValue, ",", sTokens, 2, 16);
+
+		SF2PageMusicEntityRangeData rangeData;
+		entData.GetRange(rangeId, rangeData);
+		
+		if (iNumTokens == 1)
+		{
+			rangeData.Min = StringToInt(sTokens[0]);
+			rangeData.Max = rangeData.Min;
+		}
+		else
+		{
+			rangeData.Min = StringToInt(sTokens[0]);
+			rangeData.Max = StringToInt(sTokens[1]);
+		}
+
+		entData.SetRange(rangeId, rangeData);
+
+		return Plugin_Handled;
+	}
+	else if (StrContains(szKeyName, "music", false) == 0)
+	{
+		char sBuffer[256];
+		strcopy(sBuffer, sizeof(sBuffer), szKeyName);
+		ReplaceStringEx(sBuffer, sizeof(sBuffer), "music", "", _, _, false);
+		
+		int rangeId = StringToInt(sBuffer) - 1;
+		if (rangeId < 0 || rangeId >= SF2MAPENTITES_PAGE_MUSIC_MAXRANGES)
+			return Plugin_Continue;
+		
+		SF2PageMusicEntityRangeData rangeData;
+		entData.GetRange(rangeId, rangeData);
+		strcopy(rangeData.Music, PLATFORM_MAX_PATH, szValue);
+		entData.SetRange(rangeId, rangeData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "layered", false) == 0)
+	{
+		entData.Layered = StringToInt(szValue) != 0;
+		SF2PageMusicEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static Action SF2PageMusicEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static void SF2PageMusicEntity_SpawnPost(int entity) 
+{
+	SF2PageMusicEntityData entData;
+	if (SF2PageMusicEntityData_Get(entity, entData) == -1)
+		return;
+
+	// Precache, or else...
+	SF2PageMusicEntityRangeData rangeData;
+
+	for (int i = 0; i < SF2MAPENTITES_PAGE_MUSIC_MAXRANGES; i++)
+	{
+		entData.GetRange(i, rangeData);
+		
+		if (rangeData.Music[0] != '\0')
+			PrecacheSound(rangeData.Music);
+	}
+}
+
+static void SF2PageMusicEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2PageMusicEntityData entData;
+	int iIndex = SF2PageMusicEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2PageMusicEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2PageMusicEntityData_Get(int entIndex, SF2PageMusicEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+static int SF2PageMusicEntityData_Update(SF2PageMusicEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}

--- a/addons/sourcemod/scripting/sf2/entities/sf2_info_page_spawn.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_info_page_spawn.sp
@@ -1,0 +1,257 @@
+// sf2_info_page_spawn
+
+static const char g_sEntityClassname[] = "sf2_info_page_spawn"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "info_target"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+/**
+ *	Internal data stored for the entity.
+ */
+enum struct SF2PageSpawnEntityData
+{
+	int EntRef;
+	char Model[PLATFORM_MAX_PATH];
+	int Skin;
+	float ModelScale;
+	char Group[64];
+	char Animation[64];
+
+	// renderamt, rendermode, and rendercolor are properties of CBaseEntity and
+	// thus do not need to be saved here.
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+		strcopy(this.Model, PLATFORM_MAX_PATH, "models/slender/sheet.mdl");
+		this.Skin = -1;
+		this.ModelScale = 1.0;
+		this.Group[0] = '\0';
+		this.Animation[0] = '\0';
+	}
+
+	void SetModel(const char[] sModel)
+	{
+		strcopy(this.Model, PLATFORM_MAX_PATH, sModel);
+	}
+
+	void SetGroup(const char[] sGroupName)
+	{
+		strcopy(this.Group, 64, sGroupName);
+	}
+
+	void SetAnimation(const char[] sAnimation)
+	{
+		strcopy(this.Animation, 64, sAnimation);
+	}
+
+	void Destroy()
+	{
+	}
+}
+
+/**
+ *	Interface that exposes public methods for interacting with the entity.
+ */
+methodmap SF2PageSpawnEntity < SF2MapEntity
+{
+	public SF2PageSpawnEntity(int entIndex) { return view_as<SF2PageSpawnEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2PageSpawnEntityData entData;
+		return (SF2PageSpawnEntityData_Get(this.EntRef, entData) != -1);
+	}
+
+	public void GetModel(char[] sBuffer, int iBufferLen)
+	{
+		SF2PageSpawnEntityData entData; SF2PageSpawnEntityData_Get(this.EntRef, entData);
+		strcopy(sBuffer, iBufferLen, entData.Model);
+	}
+
+	property int Skin
+	{
+		public get() { SF2PageSpawnEntityData entData; SF2PageSpawnEntityData_Get(this.EntRef, entData); return entData.Skin; }
+	}
+
+	property float ModelScale
+	{
+		public get() { SF2PageSpawnEntityData entData; SF2PageSpawnEntityData_Get(this.EntRef, entData); return entData.ModelScale; }
+	}
+
+	public void GetGroup(char[] sBuffer, int iBufferLen)
+	{
+		SF2PageSpawnEntityData entData; SF2PageSpawnEntityData_Get(this.EntRef, entData);
+		strcopy(sBuffer, iBufferLen, entData.Group);
+	}
+
+	public void GetAnimation(char[] sBuffer, int iBufferLen)
+	{
+		SF2PageSpawnEntityData entData; SF2PageSpawnEntityData_Get(this.EntRef, entData);
+		strcopy(sBuffer, iBufferLen, entData.Animation);
+	}
+
+	public void GetRenderColor(int& r, int& g, int& b, int& a)
+	{
+		GetEntityRenderColor(this.EntRef, r, g, b, a);
+	}
+
+	property RenderFx RenderFx
+	{
+		public get() { return GetEntityRenderFx(this.EntRef); }
+	}
+
+	property RenderMode RenderMode
+	{
+		public get() { return GetEntityRenderMode(this.EntRef); }
+	}
+}
+
+void SF2PageSpawnEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2PageSpawnEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2PageSpawnEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2PageSpawnEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2PageSpawnEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2PageSpawnEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2PageSpawnEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PageSpawnEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PageSpawnEntity_OnMapStart);
+}
+
+static void SF2PageSpawnEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2PageSpawnEntity_OnMapStart() 
+{
+}
+
+static void SF2PageSpawnEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2PageSpawnEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2PageSpawnEntity_SpawnPost);
+
+	SetEntityRenderColor(entity, 255, 255, 255, 255);
+}
+
+static Action SF2PageSpawnEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2PageSpawnEntityData entData;
+	if (SF2PageSpawnEntityData_Get(entity, entData) == -1)
+		return Plugin_Continue;
+	
+	if (strcmp(szKeyName, "model", false) == 0)
+	{
+		entData.SetModel(szValue);
+		SF2PageSpawnEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "skin", false) == 0)
+	{
+		entData.Skin = StringToInt(szValue);
+		SF2PageSpawnEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "modelscale", false) == 0)
+	{
+		entData.ModelScale = StringToFloat(szValue);
+		SF2PageSpawnEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "group", false) == 0)
+	{
+		entData.SetGroup(szValue);
+		SF2PageSpawnEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "animation", false) == 0)
+	{
+		entData.SetAnimation(szValue);
+		SF2PageSpawnEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static Action SF2PageSpawnEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static void SF2PageSpawnEntity_SpawnPost(int entity) 
+{
+	SF2PageSpawnEntityData entData; SF2PageSpawnEntityData_Get(entity, entData);
+
+	if (entData.Model[0] != '\0')
+		PrecacheModel(entData.Model); // Precache, or else...
+}
+
+static void SF2PageSpawnEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2PageSpawnEntityData entData;
+	int iIndex = SF2PageSpawnEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2PageSpawnEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2PageSpawnEntityData_Get(int entIndex, SF2PageSpawnEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+static int SF2PageSpawnEntityData_Update(SF2PageSpawnEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}

--- a/addons/sourcemod/scripting/sf2/entities/sf2_info_player_escapespawn.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_info_player_escapespawn.sp
@@ -1,0 +1,179 @@
+// sf2_info_player_escapespawn
+
+static const char g_sEntityClassname[] = "sf2_info_player_escapespawn"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "info_target"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+enum struct SF2PlayerEscapeSpawnEntityData
+{
+	int EntRef;
+	bool Enabled;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+		this.Enabled = true;
+	}
+
+	void Destroy()
+	{
+	}
+}
+
+methodmap SF2PlayerEscapeSpawnEntity < SF2MapEntity
+{
+	public SF2PlayerEscapeSpawnEntity(int entIndex) { return view_as<SF2PlayerEscapeSpawnEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2PlayerEscapeSpawnEntityData entData;
+		return (SF2PlayerEscapeSpawnEntityData_Get(this.EntRef, entData) != -1);
+	}
+
+	property bool Enabled
+	{
+		public get() 
+		{
+			SF2PlayerEscapeSpawnEntityData entData; SF2PlayerEscapeSpawnEntityData_Get(this.EntRef, entData); return entData.Enabled;
+		}
+	}
+}
+
+void SF2PlayerEscapeSpawnEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2PlayerEscapeSpawnEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2PlayerEscapeSpawnEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2PlayerEscapeSpawnEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2PlayerEscapeSpawnEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2PlayerEscapeSpawnEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2PlayerEscapeSpawnEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PlayerEscapeSpawnEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PlayerEscapeSpawnEntity_OnMapStart);
+}
+
+static void SF2PlayerEscapeSpawnEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2PlayerEscapeSpawnEntity_OnMapStart() 
+{
+}
+
+static void SF2PlayerEscapeSpawnEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2PlayerEscapeSpawnEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2PlayerEscapeSpawnEntity_SpawnPost);
+}
+
+static Action SF2PlayerEscapeSpawnEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2PlayerEscapeSpawnEntityData entData;
+	if (SF2PlayerEscapeSpawnEntityData_Get(entity, entData) == -1)
+		return Plugin_Continue;
+
+	SF2PlayerEscapeSpawnEntity spawnPoint = SF2PlayerEscapeSpawnEntity(entity);
+	
+	if (strcmp(szKeyName, "startdisabled", false) == 0)
+	{
+		entData.Enabled = StringToInt(szValue) == 0;
+		SF2PlayerEscapeSpawnEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "OnSpawn", false) == 0)
+	{
+		spawnPoint.AddOutput(szKeyName, szValue);
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static Action SF2PlayerEscapeSpawnEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2PlayerEscapeSpawnEntityData entData;
+	if (SF2PlayerEscapeSpawnEntityData_Get(entity, entData) == -1)
+		return Plugin_Continue;
+
+	if (strcmp(szInputName, "Enable", false) == 0)
+	{
+		entData.Enabled = true;
+		SF2PlayerEscapeSpawnEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "Disable", false) == 0)
+	{
+		entData.Enabled = false;
+		SF2PlayerEscapeSpawnEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static void SF2PlayerEscapeSpawnEntity_SpawnPost(int entity) 
+{
+}
+
+static void SF2PlayerEscapeSpawnEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2PlayerEscapeSpawnEntityData entData;
+	int iIndex = SF2PlayerEscapeSpawnEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2PlayerEscapeSpawnEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2PlayerEscapeSpawnEntityData_Get(int entIndex, SF2PlayerEscapeSpawnEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+static int SF2PlayerEscapeSpawnEntityData_Update(SF2PlayerEscapeSpawnEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}

--- a/addons/sourcemod/scripting/sf2/entities/sf2_info_player_proxyspawn.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_info_player_proxyspawn.sp
@@ -1,0 +1,207 @@
+// sf2_info_player_proxyspawn
+
+static const char g_sEntityClassname[] = "sf2_info_player_proxyspawn"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "info_target"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+enum struct SF2PlayerProxySpawnEntityData
+{
+	int EntRef;
+	bool Enabled;
+	bool IgnoreVisibility;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+		this.Enabled = true;
+		this.IgnoreVisibility = false;
+	}
+
+	void Destroy()
+	{
+	}
+}
+
+methodmap SF2PlayerProxySpawnEntity < SF2MapEntity
+{
+	public SF2PlayerProxySpawnEntity(int entIndex) { return view_as<SF2PlayerProxySpawnEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2PlayerProxySpawnEntityData entData;
+		return (SF2PlayerProxySpawnEntityData_Get(this.EntRef, entData) != -1);
+	}
+
+	property bool Enabled
+	{
+		public get() 
+		{
+			SF2PlayerProxySpawnEntityData entData; SF2PlayerProxySpawnEntityData_Get(this.EntRef, entData); return entData.Enabled;
+		}
+	}
+
+	property bool IgnoreVisibility
+	{
+		public get() 
+		{
+			SF2PlayerProxySpawnEntityData entData; SF2PlayerProxySpawnEntityData_Get(this.EntRef, entData); return entData.IgnoreVisibility;
+		}
+	}
+}
+
+void SF2PlayerProxySpawnEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2PlayerProxySpawnEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2PlayerProxySpawnEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2PlayerProxySpawnEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2PlayerProxySpawnEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2PlayerProxySpawnEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2PlayerProxySpawnEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PlayerProxySpawnEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PlayerProxySpawnEntity_OnMapStart);
+}
+
+static void SF2PlayerProxySpawnEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2PlayerProxySpawnEntity_OnMapStart() 
+{
+}
+
+static void SF2PlayerProxySpawnEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2PlayerProxySpawnEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2PlayerProxySpawnEntity_SpawnPost);
+}
+
+static Action SF2PlayerProxySpawnEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2PlayerProxySpawnEntityData entData;
+	if (SF2PlayerProxySpawnEntityData_Get(entity, entData) == -1)
+		return Plugin_Continue;
+
+	SF2PlayerProxySpawnEntity spawnPoint = SF2PlayerProxySpawnEntity(entity);
+	
+	if (strcmp(szKeyName, "startdisabled", false) == 0)
+	{
+		entData.Enabled = StringToInt(szValue) == 0;
+		SF2PlayerProxySpawnEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "ignorevisibility", false) == 0)
+	{
+		entData.IgnoreVisibility = StringToInt(szValue) != 0;
+		SF2PlayerProxySpawnEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "OnSpawn", false) == 0)
+	{
+		spawnPoint.AddOutput(szKeyName, szValue);
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static Action SF2PlayerProxySpawnEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2PlayerProxySpawnEntityData entData;
+	if (SF2PlayerProxySpawnEntityData_Get(entity, entData) == -1)
+		return Plugin_Continue;
+
+	if (strcmp(szInputName, "Enable", false) == 0)
+	{
+		entData.Enabled = true;
+		SF2PlayerProxySpawnEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "Disable", false) == 0)
+	{
+		entData.Enabled = false;
+		SF2PlayerProxySpawnEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "EnableIgnoreVisibility", false) == 0)
+	{
+		entData.IgnoreVisibility = true;
+		SF2PlayerProxySpawnEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "DisableIgnoreVisibility", false) == 0)
+	{
+		entData.IgnoreVisibility = false;
+		SF2PlayerProxySpawnEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static void SF2PlayerProxySpawnEntity_SpawnPost(int entity) 
+{
+}
+
+static void SF2PlayerProxySpawnEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2PlayerProxySpawnEntityData entData;
+	int iIndex = SF2PlayerProxySpawnEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2PlayerProxySpawnEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2PlayerProxySpawnEntityData_Get(int entIndex, SF2PlayerProxySpawnEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+static int SF2PlayerProxySpawnEntityData_Update(SF2PlayerProxySpawnEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}

--- a/addons/sourcemod/scripting/sf2/entities/sf2_info_player_pvpspawn.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_info_player_pvpspawn.sp
@@ -1,0 +1,179 @@
+// sf2_info_player_pvpspawn
+
+static const char g_sEntityClassname[] = "sf2_info_player_pvpspawn"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "info_target"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+enum struct SF2PlayerPvPSpawnEntityData
+{
+	int EntRef;
+	bool Enabled;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+		this.Enabled = true;
+	}
+
+	void Destroy()
+	{
+	}
+}
+
+methodmap SF2PlayerPvPSpawnEntity < SF2MapEntity
+{
+	public SF2PlayerPvPSpawnEntity(int entIndex) { return view_as<SF2PlayerPvPSpawnEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2PlayerPvPSpawnEntityData entData;
+		return (SF2PlayerPvPSpawnEntityData_Get(this.EntRef, entData) != -1);
+	}
+
+	property bool Enabled
+	{
+		public get() 
+		{
+			SF2PlayerPvPSpawnEntityData entData; SF2PlayerPvPSpawnEntityData_Get(this.EntRef, entData); return entData.Enabled;
+		}
+	}
+}
+
+void SF2PlayerPvPSpawnEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2PlayerPvPSpawnEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2PlayerPvPSpawnEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2PlayerPvPSpawnEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2PlayerPvPSpawnEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2PlayerPvPSpawnEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2PlayerPvPSpawnEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PlayerPvPSpawnEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PlayerPvPSpawnEntity_OnMapStart);
+}
+
+static void SF2PlayerPvPSpawnEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2PlayerPvPSpawnEntity_OnMapStart() 
+{
+}
+
+static void SF2PlayerPvPSpawnEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2PlayerPvPSpawnEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2PlayerPvPSpawnEntity_SpawnPost);
+}
+
+static Action SF2PlayerPvPSpawnEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2PlayerPvPSpawnEntityData entData;
+	if (SF2PlayerPvPSpawnEntityData_Get(entity, entData) == -1)
+		return Plugin_Continue;
+
+	SF2PlayerPvPSpawnEntity spawnPoint = SF2PlayerPvPSpawnEntity(entity);
+	
+	if (strcmp(szKeyName, "startdisabled", false) == 0)
+	{
+		entData.Enabled = StringToInt(szValue) == 0;
+		SF2PlayerPvPSpawnEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "OnSpawn", false) == 0)
+	{
+		spawnPoint.AddOutput(szKeyName, szValue);
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static Action SF2PlayerPvPSpawnEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2PlayerPvPSpawnEntityData entData;
+	if (SF2PlayerPvPSpawnEntityData_Get(entity, entData) == -1)
+		return Plugin_Continue;
+
+	if (strcmp(szInputName, "Enable", false) == 0)
+	{
+		entData.Enabled = true;
+		SF2PlayerPvPSpawnEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "Disable", false) == 0)
+	{
+		entData.Enabled = false;
+		SF2PlayerPvPSpawnEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static void SF2PlayerPvPSpawnEntity_SpawnPost(int entity) 
+{
+}
+
+static void SF2PlayerPvPSpawnEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2PlayerPvPSpawnEntityData entData;
+	int iIndex = SF2PlayerPvPSpawnEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2PlayerPvPSpawnEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2PlayerPvPSpawnEntityData_Get(int entIndex, SF2PlayerPvPSpawnEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+static int SF2PlayerPvPSpawnEntityData_Update(SF2PlayerPvPSpawnEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}

--- a/addons/sourcemod/scripting/sf2/entities/sf2_logic_arena.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_logic_arena.sp
@@ -1,0 +1,249 @@
+// sf2_logic_arena
+
+static const char g_sEntityClassname[] = "sf2_logic_arena"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "info_target"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+/**
+ *	Internal data stored for the entity.
+ */
+enum struct SF2LogicRenevantEntityData
+{
+	int EntRef;
+	int FinaleTime;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+		this.FinaleTime = 60;
+	}
+
+	void Destroy()
+	{
+	}
+}
+
+/**
+ *	Interface that exposes public methods for interacting with the entity.
+ */
+methodmap SF2LogicRenevantEntity < SF2MapEntity
+{
+	public SF2LogicRenevantEntity(int entIndex) { return view_as<SF2LogicRenevantEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2LogicRenevantEntityData entData;
+		return (SF2LogicRenevantEntityData_Get(this.EntRef, entData) != -1);
+	}
+
+	property int FinaleTime
+	{
+		public get() 
+		{
+			SF2LogicRenevantEntityData entData; SF2LogicRenevantEntityData_Get(this.EntRef, entData); return entData.FinaleTime;
+		}
+	}
+}
+
+SF2LogicRenevantEntity FindLogicRenevantEntity()
+{
+	int ent = -1;
+	while ((ent = FindEntityByClassname(ent, g_sEntityClassname)) != -1)
+	{
+		SF2LogicRenevantEntity renevantLogic = SF2LogicRenevantEntity(ent);
+		if (!renevantLogic.IsValid())
+			continue;
+
+		return renevantLogic;
+	}
+
+	return SF2LogicRenevantEntity(-1);
+}
+
+void SF2LogicRenevantEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2LogicRenevantEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2LogicRenevantEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2LogicRenevantEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2LogicRenevantEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicRenevantEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicRenevantEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicRenevantEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicRenevantEntity_OnMapStart);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnRenevantWaveTriggered, SF2LogicRenevantEntity_OnRenevantWaveTriggered);
+}
+
+static void SF2LogicRenevantEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2LogicRenevantEntity_OnMapStart() 
+{
+}
+
+static void SF2LogicRenevantEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2LogicRenevantEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2LogicRenevantEntity_SpawnPost);
+}
+
+static Action SF2LogicRenevantEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2LogicRenevantEntityData entData;
+	int iIndex = SF2LogicRenevantEntityData_Get(entity, entData);
+	if (iIndex == -1)
+		return Plugin_Continue;
+
+	SF2LogicRenevantEntity logicEnt = SF2LogicRenevantEntity(entity);
+
+	if (strcmp(szKeyName, "finaletime", false) == 0)
+	{
+		int iFinaleTime = StringToInt(szValue);
+		if (iFinaleTime < 0) iFinaleTime = 0;
+
+		entData.FinaleTime = iFinaleTime;
+		SF2LogicRenevantEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "OnRequestWave", false) == 0 ||
+		strcmp(szKeyName, "OnWaveTriggered", false) == 0)
+	{
+		logicEnt.AddOutput(szKeyName, szValue);
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static void SF2LogicRenevantEntity_OnRenevantWaveTriggered(int iWave)
+{
+	SF2MapEntityVariant inputVariant;
+	inputVariant.Init();
+	inputVariant.SetInt(iWave);
+
+	for (int i = 0; i < g_EntityData.Length; i++) 
+	{
+		SF2LogicRenevantEntityData entData;
+		g_EntityData.GetArray(i, entData, sizeof(entData));
+
+		if (!IsValidEntity(entData.EntRef))
+			continue;
+
+		SF2LogicRenevantEntity logicEnt = SF2LogicRenevantEntity(entData.EntRef);
+
+		logicEnt.FireOutput("OnWaveTriggered", entData.EntRef, entData.EntRef, inputVariant);
+	}
+}
+
+static Action SF2LogicRenevantEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2LogicRenevantEntityData entData;
+	int iIndex = SF2LogicRenevantEntityData_Get(entity, entData);
+	if (iIndex == -1)
+		return Plugin_Continue;
+	
+	SF2LogicRenevantEntity logicEnt = SF2LogicRenevantEntity(entity);
+
+	if (strcmp(szInputName, "SetWave", false) == 0)
+	{
+		int iWave = SF2MapEntity_GetIntFromVariant();
+		if (iWave < 0)
+			iWave = 0;
+		if (iWave > RENEVANT_MAXWAVES)
+			iWave = RENEVANT_MAXWAVES;
+		
+		Renevant_SetWave(iWave);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetWaveResetTimer", false) == 0)
+	{
+		int iWave = SF2MapEntity_GetIntFromVariant();
+		if (iWave < 0)
+			iWave = 0;
+		if (iWave > RENEVANT_MAXWAVES)
+			iWave = RENEVANT_MAXWAVES;
+		
+		Renevant_SetWave(iWave, true);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "RequestWave", false) == 0)
+	{
+		SF2MapEntityVariant inputVariant;
+		inputVariant.Init();
+		inputVariant.SetInt(g_iRenevantWaveNumber);
+		logicEnt.FireOutput("OnRequestWave", activator, caller, inputVariant);
+
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static void SF2LogicRenevantEntity_SpawnPost(int entity) 
+{
+}
+
+static void SF2LogicRenevantEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2LogicRenevantEntityData entData;
+	int iIndex = SF2LogicRenevantEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2LogicRenevantEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2LogicRenevantEntityData_Get(int entIndex, SF2LogicRenevantEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+static int SF2LogicRenevantEntityData_Update(SF2LogicRenevantEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}

--- a/addons/sourcemod/scripting/sf2/entities/sf2_logic_boxing.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_logic_boxing.sp
@@ -1,0 +1,157 @@
+// sf2_logic_boxing
+
+static const char g_sEntityClassname[] = "sf2_logic_boxing"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "info_target"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+/**
+ *	Internal data stored for the entity.
+ */
+enum struct SF2LogicBoxingEntityData
+{
+	int EntRef;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+	}
+
+	void Destroy()
+	{
+	}
+}
+
+/**
+ *	Interface that exposes public methods for interacting with the entity.
+ */
+methodmap SF2LogicBoxingEntity < SF2MapEntity
+{
+	public SF2LogicBoxingEntity(int entIndex) { return view_as<SF2LogicBoxingEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2LogicBoxingEntityData entData;
+		return (SF2LogicBoxingEntityData_Get(this.EntRef, entData) != -1);
+	}
+}
+
+SF2LogicBoxingEntity FindLogicBoxingEntity()
+{
+	int ent = -1;
+	while ((ent = FindEntityByClassname(ent, g_sEntityClassname)) != -1)
+	{
+		SF2LogicBoxingEntity raidLogic = SF2LogicBoxingEntity(ent);
+		if (!raidLogic.IsValid())
+			continue;
+
+		return raidLogic;
+	}
+
+	return SF2LogicBoxingEntity(-1);
+}
+
+void SF2LogicBoxingEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2LogicBoxingEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2LogicBoxingEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2LogicBoxingEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2LogicBoxingEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicBoxingEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicBoxingEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicBoxingEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicBoxingEntity_OnMapStart);
+}
+
+static void SF2LogicBoxingEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2LogicBoxingEntity_OnMapStart() 
+{
+}
+
+static void SF2LogicBoxingEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2LogicBoxingEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2LogicBoxingEntity_SpawnPost);
+}
+
+static Action SF2LogicBoxingEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static Action SF2LogicBoxingEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static void SF2LogicBoxingEntity_SpawnPost(int entity) 
+{
+}
+
+static void SF2LogicBoxingEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2LogicBoxingEntityData entData;
+	int iIndex = SF2LogicBoxingEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2LogicBoxingEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2LogicBoxingEntityData_Get(int entIndex, SF2LogicBoxingEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+/*
+static int SF2LogicBoxingEntityData_Update(SF2LogicBoxingEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}
+*/

--- a/addons/sourcemod/scripting/sf2/entities/sf2_logic_proxy.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_logic_proxy.sp
@@ -1,0 +1,157 @@
+// sf2_logic_proxy
+
+static const char g_sEntityClassname[] = "sf2_logic_proxy"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "info_target"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+/**
+ *	Internal data stored for the entity.
+ */
+enum struct SF2LogicProxyEntityData
+{
+	int EntRef;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+	}
+
+	void Destroy()
+	{
+	}
+}
+
+/**
+ *	Interface that exposes public methods for interacting with the entity.
+ */
+methodmap SF2LogicProxyEntity < SF2MapEntity
+{
+	public SF2LogicProxyEntity(int entIndex) { return view_as<SF2LogicProxyEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2LogicProxyEntityData entData;
+		return (SF2LogicProxyEntityData_Get(this.EntRef, entData) != -1);
+	}
+}
+
+SF2LogicProxyEntity FindLogicProxyEntity()
+{
+	int ent = -1;
+	while ((ent = FindEntityByClassname(ent, g_sEntityClassname)) != -1)
+	{
+		SF2LogicProxyEntity raidLogic = SF2LogicProxyEntity(ent);
+		if (!raidLogic.IsValid())
+			continue;
+
+		return raidLogic;
+	}
+
+	return SF2LogicProxyEntity(-1);
+}
+
+void SF2LogicProxyEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2LogicProxyEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2LogicProxyEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2LogicProxyEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2LogicProxyEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicProxyEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicProxyEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicProxyEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicProxyEntity_OnMapStart);
+}
+
+static void SF2LogicProxyEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2LogicProxyEntity_OnMapStart() 
+{
+}
+
+static void SF2LogicProxyEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2LogicProxyEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2LogicProxyEntity_SpawnPost);
+}
+
+static Action SF2LogicProxyEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static Action SF2LogicProxyEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static void SF2LogicProxyEntity_SpawnPost(int entity) 
+{
+}
+
+static void SF2LogicProxyEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2LogicProxyEntityData entData;
+	int iIndex = SF2LogicProxyEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2LogicProxyEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2LogicProxyEntityData_Get(int entIndex, SF2LogicProxyEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+/*
+static int SF2LogicProxyEntityData_Update(SF2LogicProxyEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}
+*/

--- a/addons/sourcemod/scripting/sf2/entities/sf2_logic_raid.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_logic_raid.sp
@@ -1,0 +1,157 @@
+// sf2_logic_raid
+
+static const char g_sEntityClassname[] = "sf2_logic_raid"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "info_target"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+/**
+ *	Internal data stored for the entity.
+ */
+enum struct SF2LogicRaidEntityData
+{
+	int EntRef;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+	}
+
+	void Destroy()
+	{
+	}
+}
+
+/**
+ *	Interface that exposes public methods for interacting with the entity.
+ */
+methodmap SF2LogicRaidEntity < SF2MapEntity
+{
+	public SF2LogicRaidEntity(int entIndex) { return view_as<SF2LogicRaidEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2LogicRaidEntityData entData;
+		return (SF2LogicRaidEntityData_Get(this.EntRef, entData) != -1);
+	}
+}
+
+SF2LogicRaidEntity FindLogicRaidEntity()
+{
+	int ent = -1;
+	while ((ent = FindEntityByClassname(ent, g_sEntityClassname)) != -1)
+	{
+		SF2LogicRaidEntity raidLogic = SF2LogicRaidEntity(ent);
+		if (!raidLogic.IsValid())
+			continue;
+
+		return raidLogic;
+	}
+
+	return SF2LogicRaidEntity(-1);
+}
+
+void SF2LogicRaidEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2LogicRaidEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2LogicRaidEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2LogicRaidEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2LogicRaidEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicRaidEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicRaidEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicRaidEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicRaidEntity_OnMapStart);
+}
+
+static void SF2LogicRaidEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2LogicRaidEntity_OnMapStart() 
+{
+}
+
+static void SF2LogicRaidEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2LogicRaidEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2LogicRaidEntity_SpawnPost);
+}
+
+static Action SF2LogicRaidEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static Action SF2LogicRaidEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static void SF2LogicRaidEntity_SpawnPost(int entity) 
+{
+}
+
+static void SF2LogicRaidEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2LogicRaidEntityData entData;
+	int iIndex = SF2LogicRaidEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2LogicRaidEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2LogicRaidEntityData_Get(int entIndex, SF2LogicRaidEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+/*
+static int SF2LogicRaidEntityData_Update(SF2LogicRaidEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}
+*/

--- a/addons/sourcemod/scripting/sf2/entities/sf2_logic_slaughter.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_logic_slaughter.sp
@@ -1,0 +1,157 @@
+// sf2_logic_slaughter
+
+static const char g_sEntityClassname[] = "sf2_logic_slaughter"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "info_target"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+/**
+ *	Internal data stored for the entity.
+ */
+enum struct SF2LogicSlaughterEntityData
+{
+	int EntRef;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+	}
+
+	void Destroy()
+	{
+	}
+}
+
+/**
+ *	Interface that exposes public methods for interacting with the entity.
+ */
+methodmap SF2LogicSlaughterEntity < SF2MapEntity
+{
+	public SF2LogicSlaughterEntity(int entIndex) { return view_as<SF2LogicSlaughterEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2LogicSlaughterEntityData entData;
+		return (SF2LogicSlaughterEntityData_Get(this.EntRef, entData) != -1);
+	}
+}
+
+SF2LogicSlaughterEntity FindLogicSlaughterEntity()
+{
+	int ent = -1;
+	while ((ent = FindEntityByClassname(ent, g_sEntityClassname)) != -1)
+	{
+		SF2LogicSlaughterEntity raidLogic = SF2LogicSlaughterEntity(ent);
+		if (!raidLogic.IsValid())
+			continue;
+
+		return raidLogic;
+	}
+
+	return SF2LogicSlaughterEntity(-1);
+}
+
+void SF2LogicSlaughterEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2LogicSlaughterEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2LogicSlaughterEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2LogicSlaughterEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2LogicSlaughterEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicSlaughterEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicSlaughterEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicSlaughterEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicSlaughterEntity_OnMapStart);
+}
+
+static void SF2LogicSlaughterEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2LogicSlaughterEntity_OnMapStart() 
+{
+}
+
+static void SF2LogicSlaughterEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2LogicSlaughterEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2LogicSlaughterEntity_SpawnPost);
+}
+
+static Action SF2LogicSlaughterEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static Action SF2LogicSlaughterEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static void SF2LogicSlaughterEntity_SpawnPost(int entity) 
+{
+}
+
+static void SF2LogicSlaughterEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2LogicSlaughterEntityData entData;
+	int iIndex = SF2LogicSlaughterEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2LogicSlaughterEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2LogicSlaughterEntityData_Get(int entIndex, SF2LogicSlaughterEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+/*
+static int SF2LogicSlaughterEntityData_Update(SF2LogicSlaughterEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}
+*/

--- a/addons/sourcemod/scripting/sf2/entities/sf2_trigger_escape.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_trigger_escape.sp
@@ -1,0 +1,92 @@
+// sf2_trigger_escape
+
+// A trigger that when touched by a player on RED will let the player escape.
+// Escaping can only occur during the Escape phase.
+
+static const char g_sEntityClassname[] = "sf2_trigger_escape"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "trigger_multiple"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+void SF2TriggerEscapeEntity_Initialize() 
+{
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2TriggerEscapeEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2TriggerEscapeEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2TriggerEscapeEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2TriggerEscapeEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2TriggerEscapeEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2TriggerEscapeEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2TriggerEscapeEntity_OnMapStart);
+}
+
+static void SF2TriggerEscapeEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2TriggerEscapeEntity_OnMapStart() 
+{
+}
+
+static void SF2TriggerEscapeEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SDKHook(entity, SDKHook_SpawnPost, SF2TriggerEscapeEntity_SpawnPost);
+	SDKHook(entity, SDKHook_StartTouchPost, SF2TriggerEscapeEntity_OnStartTouchPost);
+	SDKHook(entity, SDKHook_EndTouchPost, SF2TriggerEscapeEntity_OnEndTouchPost);
+}
+
+static Action SF2TriggerEscapeEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static Action SF2TriggerEscapeEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static void SF2TriggerEscapeEntity_SpawnPost(int entity) 
+{
+}
+
+static void SF2TriggerEscapeEntity_OnStartTouchPost(int entity, int toucher)
+{
+	if (!g_bEnabled) return;
+
+	SF2TriggerMapEntity trigger = SF2TriggerMapEntity(entity);
+
+	if (IsRoundInEscapeObjective() && trigger.PassesTriggerFilters(toucher))
+	{
+		if (IsValidClient(toucher) && IsPlayerAlive(toucher) && !IsClientInDeathCam(toucher) && !g_bPlayerEliminated[toucher] && !DidClientEscape(toucher))
+		{
+			ClientEscape(toucher);
+			TeleportClientToEscapePoint(toucher);
+		}
+	}
+}
+
+static void SF2TriggerEscapeEntity_OnEndTouchPost(int entity, int toucher)
+{
+	if (!g_bEnabled) return;
+}
+
+static void SF2TriggerEscapeEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+}
+
+static Action SF2TriggerEscapeEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}

--- a/addons/sourcemod/scripting/sf2/entities/sf2_trigger_pvp.sp
+++ b/addons/sourcemod/scripting/sf2/entities/sf2_trigger_pvp.sp
@@ -1,0 +1,160 @@
+// sf2_trigger_pvp
+
+static const char g_sEntityClassname[] = "sf2_trigger_pvp"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "trigger_multiple"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+/**
+ *	Internal data stored for the entity.
+ */
+enum struct SF2TriggerPvPEntityData
+{
+	int EntRef;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+	}
+
+	void Destroy()
+	{
+	}
+}
+
+/**
+ *	Interface that exposes public methods for interacting with the entity.
+ */
+methodmap SF2TriggerPvPEntity < SF2MapEntity
+{
+	public SF2TriggerPvPEntity(int entIndex) { return view_as<SF2TriggerPvPEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2TriggerPvPEntityData entData;
+		return (SF2TriggerPvPEntityData_Get(this.EntRef, entData) != -1);
+	}
+}
+
+void SF2TriggerPvPEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2TriggerPvPEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2TriggerPvPEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2TriggerPvPEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2TriggerPvPEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2TriggerPvPEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2TriggerPvPEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2TriggerPvPEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2TriggerPvPEntity_OnMapStart);
+}
+
+static void SF2TriggerPvPEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2TriggerPvPEntity_OnMapStart() 
+{
+}
+
+static void SF2TriggerPvPEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2TriggerPvPEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2TriggerPvPEntity_SpawnPost);
+	SDKHook(entity, SDKHook_StartTouchPost, SF2TriggerPvPEntity_OnStartTouchPost);
+	SDKHook(entity, SDKHook_EndTouchPost, SF2TriggerPvPEntity_OnEndTouchPost);
+}
+
+static Action SF2TriggerPvPEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static Action SF2TriggerPvPEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+
+static void SF2TriggerPvPEntity_SpawnPost(int entity) 
+{
+	// Add physics object flag, so we can zap projectiles!
+	int flags = GetEntProp(entity, Prop_Data, "m_spawnflags");
+	flags |= TRIGGER_EVERYTHING_BUT_PHYSICS_DEBRIS;
+	//flags |= TRIGGER_PHYSICS_OBJECTS;
+	flags |= TRIGGER_PHYSICS_DEBRIS;
+	SetEntProp(entity, Prop_Data, "m_spawnflags", flags);
+}
+
+static void SF2TriggerPvPEntity_OnStartTouchPost(int entity, int toucher)
+{
+	PvP_OnTriggerStartTouch(entity, toucher);
+}
+
+static void SF2TriggerPvPEntity_OnEndTouchPost(int entity, int toucher)
+{
+	PvP_OnTriggerEndTouch(entity, toucher);
+}
+
+static void SF2TriggerPvPEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2TriggerPvPEntityData entData;
+	int iIndex = SF2TriggerPvPEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2TriggerPvPEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2TriggerPvPEntityData_Get(int entIndex, SF2TriggerPvPEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+/*
+static int SF2TriggerPvPEntityData_Update(SF2TriggerPvPEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}
+*/

--- a/addons/sourcemod/scripting/sf2/profiles.sp
+++ b/addons/sourcemod/scripting/sf2/profiles.sp
@@ -2114,6 +2114,15 @@ ArrayList GetSelectableRenevantBossProfileList()
 	return g_hSelectableRenevantBossProfileList;
 }
 
+bool GetRandomRenevantBossProfile(char[] sBuffer, int iBufferLen)
+{
+	if (g_hSelectableRenevantBossProfileList.Length == 0)
+		return false;
+
+	GetArrayString(g_hSelectableRenevantBossProfileList, GetRandomInt(0, g_hSelectableRenevantBossProfileList.Length - 1), sBuffer, iBufferLen);
+	return true;
+}
+
 /**
  * Returns an array of boss that didn't play in game yet.
  */

--- a/addons/sourcemod/scripting/sf2/specialround.sp
+++ b/addons/sourcemod/scripting/sf2/specialround.sp
@@ -995,6 +995,7 @@ void SpecialRoundStart()
 					ClientRemoveMusicFlag(i, MUSICF_PAGES50PERCENT);
 					ClientRemoveMusicFlag(i, MUSICF_PAGES75PERCENT);
 					g_iPlayerPageMusicMaster[i] = INVALID_ENT_REFERENCE;
+					g_iPageMusicActiveIndex[i] = -1;
 					ClientMusicStart(i, NULLSOUND, _, MUSIC_PAGE_VOLUME);
 					CreateTimer(0.1, Timer_RealismCheck, GetClientUserId(i), TIMER_FLAG_NO_MAPCHANGE);
 					StopSound(i, MUSIC_CHAN, g_strRoundIntroMusic);

--- a/addons/sourcemod/scripting/sf2/stocks.sp
+++ b/addons/sourcemod/scripting/sf2/stocks.sp
@@ -193,6 +193,14 @@ bool SDK_PointIsWithin(int iFunc, float flPos[3])
 //	ENTITY & ENTITY NETWORK FUNCTIONS
 //	==========================================================
 
+stock int EnsureEntRef(int entIndex)
+{
+	if (entIndex & (1 << 31))
+		return entIndex;
+	
+	return IsValidEntity(entIndex) ? EntIndexToEntRef(entIndex) : INVALID_ENT_REFERENCE;
+}
+
 stock void Network_HookEntity(int iEnt)
 {
 	Network_ResetEntity(iEnt);

--- a/sf2.fgd
+++ b/sf2.fgd
@@ -111,6 +111,7 @@
 
 @PointClass base(game_text) iconsprite("editor/game_text.vmt") = sf2_game_text : "A game_text entity specialized for SF2."
 [
+	input Display(string) : "Display the message text. If targetname is provided, will show text to that entity only."
 ]
 
 @SolidClass base(trigger_multiple) = sf2_trigger_escape : "A trigger brush that when touched by a RED player during Escape phase, will let that player escape the map."

--- a/sf2.fgd
+++ b/sf2.fgd
@@ -1,0 +1,242 @@
+@include "base.fgd"
+
+@BaseClass base(Targetname, Parentname, Angles) = SF2SpawnPoint
+[
+	output OnSpawn(void) : "Sent when an entity spawns at this spawnpoint. The activator is the entity that spawned."
+]
+
+@PointClass base(Targetname) = sf2_gamerules : "Proxy entity for SF2's Gamerules"
+[
+	boss(string) : "Boss" : "" : "The main boss of the map. This is set at round start."
+
+	maxplayers(integer) : "Max Players" : 8 : "Maximum amount of players per round. This is set at round start."
+
+	maxpages(integer) : "Max Pages" : 1 : "Maximum amount of pages to spawn in the round. This is set at round start."
+
+	initialtimelimit(integer) : "Time Limit (in seconds)" : 200 : "How much time the players start out with after exiting grace period. This is set at round start."
+
+	pagecollectaddtime(integer) : "Time to Add on Page Collect (in seconds)" : 30 : "How much time to add to the clock upon collecting a page. This is set at round start."
+
+	pagecollectsound(sound) : "Page Collect Sound" : "slender/slenderpagegrab.wav" : "The sound path of the sound played when collecting a page. This is set at round start."
+
+	intromusicpath(sound) : "Intro Music Path" : "slender/intro.mp3" : "The sound path to the music played during Intro phase. This is set at round start."
+
+	introfadecolor(color255) : "Intro Fade Color" : "0 0 0 255" : "The color of the fade overlayed on players during Intro phase. This is set at round start."
+
+	introfadeholdtime(float) : "Intro Fade Hold Time (in seconds)" : "9" : "The amount of time to hold the fade during Intro phase. This is set at round start."
+
+	introfadetime(float) : "Intro Fade Time (in seconds)" : "1" : "The amount of time it takes to fade out during Intro phase. This is set at round start."
+
+	escape(choices) : "Escape to Win" : 0 : "Are players required to enter an escape zone to win after collecting all pages? If not, all players will auto-escape after collecting all pages. This is set at round start." =
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+
+	escapetime(integer) : "Escape Time" : 200 : "If players have to escape, how much time (in seconds) that should be given for them. This is set at round start."
+
+	stoppagemusiconescape(choices) : "Stop Page Music on Escape" : 0 : "Stops the page music when entering the Escape phase." = 
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+
+	survive(choices) : "Survive before Escape" : 0 : "Are players required to survive before trying to escape? NOTE: If this is a Proxy Survival map (sf2_logic_proxy), this will always be Yes." =
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+
+	surviveuntiltime(integer) : "Survive Until Time (in seconds)" : 30 : "If Survive before Escape, then when the round time reaches this number, survival is complete and players must escape."
+
+	infiniteflashlight(choices) : "Infinite Flashlight" : 0 : "Enable/disable infinite flashlight. This is set at round start." =
+	[
+		0 : "Disabled"
+		1 : "Enabled"
+	]
+
+	infinitesprint(choices) : "Infinite Sprint" : 0 : "Enable/disable infinite sprint. This is set at round start." =
+	[
+		0 : "Disabled"
+		1 : "Enabled"
+	]
+
+	infiniteblink(choices) : "Infinite Blink" : 0 : "Enable/disable infinite blink. This is set at round start." =
+	[
+		0 : "Disabled"
+		1 : "Enabled"
+	]
+
+	bosseschaseendlessly(choices) : "Bosses Chase Endlessly" : 0 : "If enabled, bosses in the map will chase players endlessly. This is set at round start." =
+	[
+		0 : "Disabled"
+		1 : "Enabled"
+	]
+
+	input SetTimeLimit(integer) : "Sets the maximum time of a round."
+	input SetEscapeTimeLimit(integer) : "Sets how much time players have to escape the map, if there is an escape objective."
+	input SetTime(integer) : "Sets the current round time."
+	input SetTimeToAddOnCollectPage(integer) : "Sets the time to add to the round when collecting a page."
+	input SetCollectedPages(integer) : "Sets the amount of pages collected. This will fire the OnCollectedPagesChanged output."
+	input AddCollectedPages(integer) : "Adds the amount of pages collected. This will fire the OnCollectedPagesChanged output."
+	input SubtractCollectedPages(integer) : "Subtracts the amount of pages collected. This will fire the OnCollectedPagesChanged output."
+	input EnableInfiniteFlashlight(void) : "Enable infinite flashlight."
+	input DisableInfiniteFlashlight(void) : "Disable infinite flashlight."
+	input EnableInfiniteSprint(void) : "Enable infinite sprint."
+	input DisableInfiniteSprint(void) : "Disable infinite sprint." 
+	input EnableInfiniteBlink(void) : "Enable infinite blink."
+	input DisableInfiniteBlink(void) : "Disable infinite blink." 
+	input SetBossOverride(string) : "Sets the boss override."
+	input ClearBossOverride(void) : "Clears the boss override."
+	input SetDifficulty(integer) : "Sets the difficulty of the game, from Normal (1) to Apollyon (5). This will fire the OnDifficultyChanged output."
+	input EnableBossesChaseEndlessly(void) : "Enable bosses chasing players endlessly."
+	input DisableBossesChaseEndlessly(void) : "Disable bosses chasing players endlessly."
+	input EndGracePeriod(void) : "Ends the grace period of the round. This will fire the OnGracePeriodEnded output."
+
+	output OnStateEnterWaiting(void) : "Sent when entering the Waiting round state."
+	output OnStateExitWaiting(void) : "Sent when exiting the Waiting round state."
+	output OnStateEnterIntro(void) : "Sent when entering the Intro round state."
+	output OnStateExitIntro(void) : "Sent when exiting the Intro round state."
+	output OnStateEnterActive(void) : "Sent when entering the Active round state."
+	output OnStateExitActive(void) : "Sent when exiting the Active round state."
+	output OnStateEnterEscape(void) : "Sent when entering the Escape round state."
+	output OnStateExitEscape(void) : "Sent when exiting the Escape round state."
+	output OnStateEnterOutro(void) : "Sent when entering the Outro round state."
+	output OnStateExitOutro(void) : "Sent when exiting the Outro round state."
+	output OnGracePeriodEnded(void) : "Sent when the round's grace period ends."
+	output OnDifficultyChanged(integer) : "Sent when the game's difficulty is changed. The difficulty number is passed down as an integer."
+	output OnCollectedPagesChanged(integer) : "Sent when the collected page count changes. The page count is passed down as an integer."
+	output OnSurvivalComplete(void) : "Sent when round time reaches Survive Until Time during Escape phase."
+]
+
+@PointClass base(game_text) iconsprite("editor/game_text.vmt") = sf2_game_text : "A game_text entity specialized for SF2."
+[
+]
+
+@SolidClass base(trigger_multiple) = sf2_trigger_escape : "A trigger brush that when touched by a RED player during Escape phase, will let that player escape the map."
+[
+]
+
+@PointClass base(SF2SpawnPoint, EnableDisable) studio("models/editor/playerstart.mdl") = sf2_info_player_escapespawn : "A spawnpoint for RED players that escape the map."
+[
+]
+
+@SolidClass base(trigger_multiple) = sf2_trigger_pvp : "A trigger brush that when touched by a player will enter PvP mode."
+[
+]
+
+@PointClass base(SF2SpawnPoint, EnableDisable) studio("models/editor/playerstart.mdl") = sf2_info_player_pvpspawn : "A spawnpoint for players in PvP."
+[
+]
+
+@PointClass base(SF2SpawnPoint, EnableDisable) studio("models/editor/playerstart.mdl") = sf2_info_player_proxyspawn : "A spawnpoint for proxies in the RED play area."
+[
+	ignorevisibility(choices) : "Ignore Visibility" : 0 : "If visibility is ignored, then proxies can spawn here regardless if a RED player has LOS or not." =
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+
+	input EnableIgnoreVisibility(void) : "Starts ignoring visibility checks."
+	input DisableIgnoreVisibility(void) : "Stops ignoring visibility checks."
+]
+
+@PointClass base(Targetname) = sf2_logic_proxy : "Proxy entity for SF2 game type Proxy Survival"
+[
+]
+
+@PointClass base(Targetname) = sf2_logic_raid : "Proxy entity for SF2 game type Raid"
+[
+]
+
+@PointClass base(SF2SpawnPoint) studio("models/arrival/slenderman.mdl") = sf2_info_boss_spawn : "An entity that can spawn a boss with the matching profile at its location."
+[
+	profile(string) : "Boss Profile" : "" : "The name of the boss profile to look for."
+	max(integer) : "Max Bosses" : 1 : "Maximum amount of bosses to match when spawning."
+
+	input Spawn(void) : "Finds a boss with the matching profile name and spawns it here. If successful, this will call the OnSpawn output for each boss spawned."
+	input SetBossProfile(string) : "Sets the boss profile name to look for among active bosses."
+]
+
+@PointClass base(Targetname, Parentname, Angles) studioprop() = sf2_info_page_spawn : "The spawn point of a page."
+[
+	model(studio) : "Model" : "models/slender/sheet.mdl" : "The world model of the page entity that spawns here."
+	skin(integer) : "Skin" : -1 : "Set this to a number other than 0 to use that skin instead of the default. Setting this to -1 will make the game iterate the skins incrementally for each page entity created."
+	modelscale(float) : "Model Scale" : "1.0" : "A multiplier for the size of the model."
+	group(string) : "Group" : "" : "The group this spawn point belongs to. When the game chooses page spawn locations, if a group is chosen, then only one spawn point in that group will be used and the rest will be ignored."
+	animation(string) : "Animation" : "" : "The animation to play for the page that spawns here."
+
+	renderamt(integer) : "FX Amount (0 - 255)" : 255 : "The FX amount is used by the selected Render Mode."
+	rendercolor(color255) : "FX Color (R G B)" : "255 255 255" : "The FX color is used by the selected Render Mode."
+	rendermode(choices) : "Render Mode" : 0 : "Used to set a non-standard rendering mode on this entity. See also 'FX Amount' and 'FX Color'." =
+	[
+		0: "Normal"
+		1: "Color"
+		2: "Texture"
+		3: "Glow"
+		4: "Solid"
+		5: "Additive"
+		7: "Additive Fractional Frame"
+		9: "World Space Glow"
+	]
+]
+
+@PointClass base(Targetname) = sf2_info_page_music : "Entity that contains array of ranges and sounds to play during page collection."
+[
+	range1(string) : "Range 1" : "1,2" : "Specifies the collected page count range in which to play music. The range can be in one of two formats: <min>,<max> or just <num>. <min>, <max>, and <num> are integers, <min> specifies minimum collected page count while <max> specifies the maximum. Use <num> to play music only when collected page count is equal. Range 2-16 follow the same format. If you need more page ranges, create another sf2_info_page_music entity."
+	music1(sound) : "Range 1 Music" : "slender/newambience_1.wav" : "Music to play when collected page count is within Range 1."
+	range2(string) : "Range 2" : "3,4" : ""
+	music2(sound) : "Range 2 Music" : "slender/newambience_2.wav" : ""
+	range3(string) : "Range 3" : "5,6" : ""
+	music3(sound) : "Range 3 Music" : "slender/newambience_3.wav" : ""
+	range4(string) : "Range 4" : "7,8" : ""
+	music4(sound) : "Range 4 Music" : "slender/newambience_4.wav" : ""
+	range5(string) : "Range 5" : "" : ""
+	music5(sound) : "Range 5 Music" : "" : ""
+	range6(string) : "Range 6" : "" : ""
+	music6(sound) : "Range 6 Music" : "" : ""
+	range7(string) : "Range 7" : "" : ""
+	music7(sound) : "Range 7 Music" : "" : ""
+	range8(string) : "Range 8" : "" : ""
+	music8(sound) : "Range 8 Music" : "" : ""
+	range9(string) : "Range 9" : "" : ""
+	music9(sound) : "Range 9 Music" : "" : ""
+	range10(string) : "Range 10" : "" : ""
+	music10(sound) : "Range 10 Music" : "" : ""
+	range11(string) : "Range 11" : "" : ""
+	music11(sound) : "Range 11 Music" : "" : ""
+	range12(string) : "Range 12" : "" : ""
+	music12(sound) : "Range 12 Music" : "" : ""
+	range13(string) : "Range 13" : "" : ""
+	music13(sound) : "Range 13 Music" : "" : ""
+	range14(string) : "Range 14" : "" : ""
+	music14(sound) : "Range 14 Music" : "" : ""
+	range15(string) : "Range 15" : "" : ""
+	music15(sound) : "Range 15 Music" : "" : ""
+	range16(string) : "Range 16" : "" : ""
+	music16(sound) : "Range 16 Music" : "" : ""
+	layered(choices) : "Layered Tracks" : 0 : "(NOT IMPLEMENTED) If layered, then when the page music changes, tracks will transition fade in/out and remain synced. Recommended for page music tracks that have the same length." =
+	[
+		0: "No"
+		1: "Yes"
+	]
+]
+
+@PointClass base(Targetname) = sf2_logic_boxing : "Proxy entity for SF2 game type Boxing"
+[
+]
+
+@PointClass base(Targetname) = sf2_logic_arena : "Proxy entity for SF2 game type Arena"
+[
+	finaletime(integer) : "Finale Time (in seconds)" : 60 : "Waves will stop advancing at this many seconds before the Escape Time runs out. This should not be greater than the Escape Time set by sf2_gamerules."
+
+	input SetWave(integer) : "Sets the current wave. This will call the OnWaveTriggered output."
+	input SetWaveResetTimer(integer) : "Sets the current wave and resets the timer. This will call the OnWaveTriggered output."
+	input RequestWave(void) : "Requests the current wave number. This will call the OnRequestWave output."
+	output OnRequestWave(integer) : "Sent when the RequestWave input is called. The current wave number is passed down as an integer."
+	output OnWaveTriggered(integer) : "Sent when the wave changes. The current wave number is passed down as an integer."
+]
+
+@PointClass base(Targetname) = sf2_logic_slaughter : "Proxy entity for SF2 game type Slaughter Run"
+[
+]


### PR DESCRIPTION
An overhaul of most of the map entities that exist in SF2. Confirmed to be working well in Windows, unsure about Linux. A lot of refactoring was done with the Arena game logic and I have not tested it. If (when) bugs pop up, I'll try to fix them as soon as possible.

Anyway, hope for the best, expect the worst!

```
Added entities:
- sf2_game_text
- sf2_gamerules
- sf2_info_boss_spawn
- sf2_info_page_music
- sf2_info_page_spawn
- sf2_info_player_escapespawn
- sf2_info_player_proxyspawn
- sf2_info_player_pvpspawn
- sf2_logic_arena
- sf2_logic_boxing
- sf2_logic_proxy
- sf2_logic_raid
- sf2_logic_slaughter
- sf2_trigger_escape
- sf2_trigger_pvp

See sf2.fgd for more details

Misc:
- Fixed bug where round timer doesn't update when survival time == round time
- g_strPageCollectSound (and by extension sf2_page_sound) is now initialized at round start; no need to constantly look for entity every time a page is collected now
- DUCK_COLLECT# macros transformed into global string array
- Added "CBaseEntity::KeyValue" vtable offset
- Added "CBaseTrigger::PassesTriggerFilters" vtable offset
- sf2_escape_custommusic now only queried once at round start rather than every client music update call
- Move page reference logic from SpawnPages() into InitializeMapEntities() (single responsibility)
- Added g_iPageMusicActiveIndex to replace g_iPlayerPageMusicMaster's role
- Refactored custom music system logic in ClientUpdateMusicSystem()
- Refactored SpawnProxy()
- ClientEnableProxy() now automatically sets position and spawn point of proxy (it was already used as such anyways)
- Refactored Renevant game logic just to accomodate for the inputs (needs testing)
```

These are the map entities that are used in Slender Fortress. Each entity is listed with either their targetname (the 'Name' field with SmartEdit turned on) and classname, or just their classname.

# Core Entities

## sf2_gamerules
Defines the base rules of the game, such as max pages, max players, time limit, intro/escape parameters, etc. You should only put one of this entity at any given map.

### Properties:
- **Boss** - The main boss of the map. Set to blank to not set the main boss.
- **Max Players** - Maximum amount of players per round.
- **Max Pages** - Maximum amount of pages to spawn in the round.
- **Time Limit** - How much time the players start out with after exiting grace period.
- **Time To Add On Page Collect** - How much time to add to the clock upon collecting a page.
- **Page Collect Sound** - The sound path of the sound played when collecting a page.
- **Intro Music Path** - The sound path to the music played during Intro phase.
- **Intro Fade Color** - The color of the fade overlayed on players during Intro phase.
- **Intro Fade Hold Time** - The amount of time to hold the fade during Intro phase. Determines the overall duration of the intro sequence of the map.
- **Intro Fade Time** - The amount of time it takes to fade out during Intro phase.
- **Escape To Win** - Are players required to enter an escape zone to win after collecting all pages? If not, all players will auto-escape after collecting all pages.
- **Escape Time** - If players have to escape, how much time (in seconds) that should be given for them.
- **Stop Page Music on Escape** - Stops the page music when entering the Escape phase.
- **Survive Before Escape** - Are players required to survive before trying to escape? 
  - If this is a Proxy Survival map (sf2_logic_proxy), this will always be Yes.
- **Infinite Flashlight** - Enable/disable infinite flashlight.
- **Infinite Sprint** - Enable/disable infinite sprint.
- **Infinite Blink** - Enable/disable infinite blink.
- **Bosses Chase Endlessly** - (Modified only) If enabled, bosses in the map will chase players endlessly.

### Inputs and Outputs:
```
input SetTimeLimit(integer) : "Sets the maximum time of a round."
input SetEscapeTimeLimit(integer) : "Sets how much time players have to escape the map, if there is an escape objective."
input SetTime(integer) : "Sets the current round time."
input SetTimeToAddOnCollectPage(integer) : "Sets the time to add to the round when collecting a page."
input SetCollectedPages(integer) : "Sets the amount of pages collected. This will fire the OnCollectedPagesChanged output."
input AddCollectedPages(integer) : "Adds the amount of pages collected. This will fire the OnCollectedPagesChanged output."
input SubtractCollectedPages(integer) : "Subtracts the amount of pages collected. This will fire the OnCollectedPagesChanged output."
input EnableInfiniteFlashlight(void) : "Enable infinite flashlight."
input DisableInfiniteFlashlight(void) : "Disable infinite flashlight."
input EnableInfiniteSprint(void) : "Enable infinite sprint."
input DisableInfiniteSprint(void) : "Disable infinite sprint." 
input EnableInfiniteBlink(void) : "Enable infinite blink."
input DisableInfiniteBlink(void) : "Disable infinite blink." 
input SetBossOverride(string) : "Sets the boss override."
input ClearBossOverride(void) : "Clears the boss override."
input SetDifficulty(integer) : "Sets the difficulty of the game, from Normal (1) to Apollyon (5). This will fire the OnDifficultyChanged output."
input EnableBossesChaseEndlessly(void) : "Enable bosses chasing players endlessly."
input DisableBossesChaseEndlessly(void) : "Disable bosses chasing players endlessly."
input EndGracePeriod(void) : "Ends the grace period of the round. This will fire the OnGracePeriodEnded output."

output OnStateEnterWaiting(void) : "Sent when entering the Waiting round state."
output OnStateExitWaiting(void) : "Sent when exiting the Waiting round state."
output OnStateEnterIntro(void) : "Sent when entering the Intro round state."
output OnStateExitIntro(void) : "Sent when exiting the Intro round state."
output OnStateEnterActive(void) : "Sent when entering the Active round state."
output OnStateExitActive(void) : "Sent when exiting the Active round state."
output OnStateEnterEscape(void) : "Sent when entering the Escape round state."
output OnStateExitEscape(void) : "Sent when exiting the Escape round state."
output OnStateEnterOutro(void) : "Sent when entering the Outro round state."
output OnStateExitOutro(void) : "Sent when exiting the Outro round state."
output OnGracePeriodEnded(void) : "Sent when the round's grace period ends."
output OnDifficultyChanged(integer) : "Sent when the game's difficulty is changed. The difficulty number is passed down as an integer."
output OnCollectedPagesChanged(integer) : "Sent when the collected page count changes. The page count is passed down as an integer."
output OnSurvivalComplete(void) : "Sent when round time reaches Survive Until Time during Escape phase."
```

This replaces the following old-style entities:
- sf2_boss_override_(name)
- sf2_escape_time_limit_#
- sf2_escape_custommusic
- sf2_infiniteflashlight
- sf2_infinitesprint
- sf2_infiniteblink
- sf2_intro_fade
- sf2_intro_music
- sf2_intro_relay
- sf2_logic_escape
- sf2_maxpages_#
- sf2_maxplayers_#
- sf2_page_sound
- sf2_survival_map
- sf2_survival_time_limit_#
- sf2_time_limit_#
- sf2_time_gain_from_page_#
- sf2_bosses_chase_endlessly (Modified only)

## sf2_info_page_spawn
Defines a spawn point for a page. Comes with model selection, coloring, grouping, and even animation for the page.

**About grouping:** If a spawn point is in a Group, then when the game chooses page spawn points, only one spawn point in a group will be chosen, and the rest will be ignored. The group name can be anything, but just make it as short as possible. And the names are case-sensitive, so it's recommended to make the group name all lowercase to make it easier. If you don't want your spawn point to have a group, leave the Group blank.

### Properties:
- **Model** - The world model of the page that spawns here.
- **Skin** - The skin number of the page that spawns here. Setting this to -1 will make the game iterate the skins incrementally for each page entity created.
- **Model Scale** - A multiplier for the size of the model.
- **Group** - The group this spawn point belongs to. When the game chooses page spawn locations, if a group is chosen, then only one spawn point in that group will be used and the rest will be ignored.
- **Animation** - The animation to play for the page that spawns here.
- **FX Amount (0 - 255)** - The FX amount is used by the selected Render Mode. Applied to the page that spawns here.
- **FX Color (R G B)** - The FX color is used by the selected Render Mode. Applied to the page that spawns here.
- **Render Mode** - Used to set a non-standard rendering mode on the page entity.

This replaces the following old-style entities:
- sf2_page_model
- sf2_page_spawnpoint

## sf2_onpagecount_# (logic_relay)
When # amount of pages have been collected, this entity will fire its Trigger input. Replace the # sign with the number you want.

## sf2_game_text
A specialized game_text entity that allows maps to show text to only RED while utilizing SF2's `HudSync` object, the same method that is used by the intro/page/escape messages. This was created since game_text does not work well (or at all) in SF2. Use the **Display** input to show text to all of RED, or if provided a name, show text only to that player (!activator works too).

## sf2_info_player_escapespawn
Defines a spawn point for the RED players that escape the map, whether by entering an sf2_trigger_escape trigger brush or auto-escape. Making multiple spawn points will make the game choose a random spawn point.

### Properties:
- **Start Disabled** - If disabled, the game will ignore this spawn point.

### Inputs and Outputs:
```
input Enable(void) : "Enable this entity for spawning."
input Disable(void) : "Disable this entity for spawning."

output OnSpawn(void) : "Sent when an entity spawns at this spawnpoint. The activator is the entity that spawned."
```

This replaces the old-style sf2_escape_spawnpoint entity.

## sf2_info_page_music
Contains an array of collection page ranges and specifies what music to play to RED players according to the current collected page amount. The ranges this entity contains are **inclusive**. This entity can store up to 16 page ranges. If you need more page ranges, create another sf2_info_page_music entity.

### Properties:
- **Range 1-16** - Specifies the collected page count range in which to play music. The range can be in one of two formats: &lt;min&gt;,&lt;max&gt; or just &lt;num&gt;. &lt;min&gt;, &lt;max&gt;, and &lt;num&gt; are integers, &lt;min&gt; specifies minimum collected page count while &lt;max&gt; specifies the maximum. Use &lt;num&gt; to play music only when collected page count is equal.
- **Range 1-16 Music** - Music to play when collected page count is within the associated Range.

This replaces the old-style sf2_page_music_#-# entity.

# Intro Sequence
## sf2_intro_text_# (game_text)
This entity will display text only to RED during the intro sequence, preferably should be used as an introduction to the map name and its author in general.

All sf2_intro_text_# entities will be called in sequence, that is from 1, 2, 3, etc. until the game cannot find any more text entities. Duration of each sequence is determined by the overall display duration of the entity, including duration and fade in/out time. The first sf2_intro_text_# should start with 1.

TIP: If you want to have a delay between displaying two text entities (or the beginning), then the text entity after the first text entity should display nothing, while having a specific duration defined.

## sf2_intro_message (game_text)
Message that appears to players AFTER the intro sequence, if any. This should be preferably used to instruct the players on what to do.

# Escape Objective
## sf2_trigger_escape
A trigger brush that when touched by a RED player during the Escape phase, the RED player will escape the map and win.

This replaces the old-style sf2_escape_trigger entity.

## sf2_escape_message (game_text)
Message shown when you need to escape.

# Mini Gamemode Entities
## sf2_logic_proxy
This tells SF2 that the map is considered a Proxy Survival map.

This replaces the old-style sf2_proxy_map entity.

## sf2_logic_raid
This tells SF2 that the map is considered a RAID map. When this is the case, all bosses chase endlessly and everything related to RAID triggers.

This replaces the old-style sf2_raid_map entity.

## sf2_logic_boxing
This tells SF2 that the map is considered a Boxing map. When this is the case, all bosses chase endlessly and everything related to Boxing triggers. This entity is exclusive to Modified.

This replaces the old-style sf2_boxing_map entity.

## sf2_boxing_boss_spawn (info_npc_spawn_destination)
In Boxing, this defines the spawn point where bosses will spawn from. Invoking the FireUser1 input will spawn the boss.

## sf2_logic_boss_rage_one (logic_relay)
In Boxing, once a boss rages on the first phase, this entity gets triggered and all events that are set to be called on "Trigger" will be called. The same form of entities can be applied to sf2_logic_boss_rage_two and sf2_logic_boss_rage_three.

## sf2_logic_arena
This tells SF2 that the map is considered an Arena map. This entity is exclusive to Modified.

### Properties:
- **Finale Time** - Waves will stop advancing at this many seconds before the Escape Time runs out. This should not be greater than the Escape Time set by sf2_gamerules.

### Inputs and Outputs:
```
input SetWave(integer) : "Sets the current wave. This will call the OnWaveTriggered output."
input SetWaveResetTimer(integer) : "Sets the current wave and resets the timer. This will call the OnWaveTriggered output."
input RequestWave(void) : "Requests the current wave number. This will call the OnRequestWave output."

output OnRequestWave(integer) : "Sent when the RequestWave input is called. The current wave number is passed down as an integer."
output OnWaveTriggered(integer) : "Sent when the wave changes. The current wave number is passed down as an integer."
```

This replaces the old-style sf2_renevant_map entity.

## sf2_logic_slaughter
This tells SF2 that the map is considered a Slaughter Run map. This entity is exclusive to Modified.

This replaces the old-style sf2_slaughterrun_map entity.

# Proxy Map Entities
## sf2_info_player_proxyspawn
When this is placed, proxies will no longer spawn around the closest player the gamemode chooses, instead proxies are now set to spawn at these spawn points. It's best to allow more than one spawn point as spawn camping can be an issue despite the proxy bosses.

### Properties:
- **Start Disabled** - If disabled, the game will ignore this spawn point.
- **Ignore Visibility** - If visibility is ignored, then proxies can spawn here regardless if a RED player has LOS or not.

### Inputs and Outputs:
```
input Enable(void) : "Enable this entity for spawning."
input Disable(void) : "Disable this entity for spawning."
input EnableIgnoreVisibility(void) : "Starts ignoring visibility checks."
input DisableIgnoreVisibility(void) : "Stops ignoring visibility checks."

output OnSpawn(void) : "Sent when an entity spawns at this spawnpoint. The activator is the entity that spawned."
```

This replaces the old-style sf2_proxy_spawnpoint entity.

# PvP Entities
## sf2_trigger_pvp
A trigger which will act as a Player vs. Player zone. People will be able to kill each other with their full loadouts.

This replaces the old-style sf2_pvp_trigger entity.

## sf2_info_player_pvpspawn
Defines a spawn point for the automatic spawning feature of PvP. Making multiple spawn points will make the game choose a random spawn point.

### Properties:
- **Start Disabled** - If disabled, the game will ignore this spawn point.

### Inputs and Outputs:
```
input Enable(void) : "Enable this entity for spawning."
input Disable(void) : "Disable this entity for spawning."

output OnSpawn(void) : "Sent when an entity spawns at this spawnpoint. The activator is the entity that spawned."
```

This replaces the old-style sf2_pvp_spawnpoint entity.

# Miscellaneous Entities
## sf2_info_boss_spawn
Defines a spawn point that, when its Spawn input is invoked, will search for an active boss with the same profile name, and if found, will spawn the boss at its location.

### Properties:
- **Boss Profile** - The name of the boss profile to look for.
- **Max Bosses** - Maximum amount of bosses to match when spawning.

### Inputs and Outputs:
```
input Spawn(void) : "Finds a boss with the matching profile name and spawns it here. If successful, this will call the OnSpawn output for each boss spawned."
input SetBossProfile(string) : "Sets the boss profile name to look for among active bosses."
output OnSpawn(void) : "Sent when an entity spawns at this spawnpoint. The activator is the entity that spawned."
```

This replaces the old-style sf2_spawn_(name) entity.

## sf2_nav_interface (tf_point_nav_interface)
Place this entity into your map, and send the "RecomputeBlockers" input whenever you open a non automatic door (not linked to a trigger brush, such as the floodgate on slender_underground), or you disable a brush that was previously blocking an area ect... That interface recomputes the block tag on all nav areas, this is important to use so the boss path creation doesn't screw up your map. In order to use it properly, open your closed door, whatever blocks the way to a new area, and then send the input "RecomputeBlockers" 5 times with 1 second between each input.