### PR TITLE
Map Entities Update (Round 2)

### DIFF
--- a/addons/sourcemod/scripting/sf2/client.sp
+++ b/addons/sourcemod/scripting/sf2/client.sp
@@ -5859,12 +5859,7 @@ stock void ClientMusicStart(int client, const char[] sNewMusic, float flVolume=-
 	{
 		bool bPlayMusicOnEscape = !g_bRoundStopPageMusicOnEscape;
 
-		if(g_iPageCount < g_iPageMax)
-		{
-			g_hPlayerMusicTimer[client] = CreateTimer(0.01, Timer_PlayerFadeInMusic, GetClientUserId(client), TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
-			TriggerTimer(g_hPlayerMusicTimer[client], true);
-		}
-		if(!bPlayMusicOnEscape)
+		if (g_iPageCount < g_iPageMax || bPlayMusicOnEscape)
 		{
 			g_hPlayerMusicTimer[client] = CreateTimer(0.01, Timer_PlayerFadeInMusic, GetClientUserId(client), TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
 			TriggerTimer(g_hPlayerMusicTimer[client], true);

--- a/addons/sourcemod/scripting/sf2/mapentities.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities.sp
@@ -209,6 +209,7 @@ void SF2MapEntity_AddHook(SF2MapEntityHook hookType, Function hookFunc)
 #include "sf2/mapentities/sf2_info_page_music.sp"
 #include "sf2/mapentities/sf2_logic_proxy.sp"
 #include "sf2/mapentities/sf2_logic_raid.sp"
+#include "sf2/mapentities/sf2_boss_maker.sp"
 
 // Modified only
 #include "sf2/mapentities/sf2_logic_arena.sp"
@@ -370,6 +371,9 @@ void SF2MapEntity_Initialize()
 
 	// sf2_logic_raid
 	SF2LogicRaidEntity_Initialize();
+
+	// sf2_boss_maker
+	SF2BossMakerEntity_Initialize();
 
 	// Modified
 	

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_boss_maker.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_boss_maker.sp
@@ -199,6 +199,8 @@ methodmap SF2BossMakerEntity < SF2MapEntity
 		int iBossEntIndex = NPCGetEntIndex(iBossIndex);
 		if (IsValidEntity(iBossEntIndex))
 		{
+			TeleportEntity(iBossEntIndex, NULL_VECTOR, flAng, NULL_VECTOR);
+
 			if (!(iSpawnFlags & SF_SF2_BOSS_MAKER_NODROP))
 			{
 				// Drop (teleport) it to the ground.

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_boss_maker.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_boss_maker.sp
@@ -1,0 +1,651 @@
+// sf2_boss_maker
+
+static const char g_sEntityClassname[] = "sf2_boss_maker"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "info_target"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+#define SF_SF2_BOSS_MAKER_NODROP 1
+#define SF_SF2_BOSS_MAKER_ADDONLY 2
+#define SF_SF2_BOSS_MAKER_FAKE 4
+#define SF_SF2_BOSS_MAKER_NOTELEPORT 8
+#define SF_SF2_BOSS_MAKER_ATTACKWAITERS 16
+#define SF_SF2_BOSS_MAKER_NOCOMPANIONS 32
+#define SF_SF2_BOSS_MAKER_NOSPAWNSOUND 64
+#define SF_SF2_BOSS_MAKER_NOCOPIES 128
+
+/**
+ *	Internal data stored for the entity.
+ */
+enum struct SF2BossMakerEntityData
+{
+	int EntRef;
+	char BossProfile[SF2_MAX_PROFILE_NAME_LENGTH];
+	int SpawnCount;
+	float SpawnRadius;
+	int MaxLiveBosses;
+	int SpawnDestination;
+	char SpawnDestinationName[64];
+	char SpawnAnimation[64];
+	float SpawnAnimationPlaybackRate;
+	float SpawnAnimationDuration;
+	ArrayList Bosses;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+		this.BossProfile[0] = '\0';
+		this.SpawnCount = 1;
+		this.SpawnRadius = 0.0;
+		this.MaxLiveBosses = -1;
+		this.SpawnDestination = INVALID_ENT_REFERENCE;
+		this.SpawnDestinationName[0] = '\0';
+		this.SpawnAnimation[0] = '\0';
+		this.SpawnAnimationPlaybackRate = 1.0;
+		this.SpawnAnimationDuration = 0.0;
+
+		this.Bosses = new ArrayList();
+	}
+
+	void Destroy()
+	{
+		if (this.Bosses != null)
+			delete this.Bosses;
+	}
+
+	void SetBossProfile(const char[] sProfile)
+	{
+		strcopy(this.BossProfile, SF2_MAX_PROFILE_NAME_LENGTH, sProfile);
+	}
+
+	void SetSpawnDestinationName(const char[] sTargetName)
+	{
+		strcopy(this.SpawnDestinationName, 64, sTargetName);
+	}
+
+	void SetSpawnAnimation(const char[] sAnimation)
+	{
+		strcopy(this.SpawnAnimation, 64, sAnimation);
+	}
+}
+
+/**
+ *	Interface that exposes public methods for interacting with the entity.
+ */
+methodmap SF2BossMakerEntity < SF2MapEntity
+{
+	public SF2BossMakerEntity(int entIndex) { return view_as<SF2BossMakerEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2BossMakerEntityData entData;
+		return (SF2BossMakerEntityData_Get(this.EntRef, entData) != -1);
+	}
+
+	public void GetBossProfile(char[] sBuffer, int iBufferLen)
+	{
+		SF2BossMakerEntityData entData; SF2BossMakerEntityData_Get(this.EntRef, entData); 
+		strcopy(sBuffer, iBufferLen, entData.BossProfile);
+	}
+
+	property int SpawnCount
+	{
+		public get() { SF2BossMakerEntityData entData; SF2BossMakerEntityData_Get(this.EntRef, entData); return entData.SpawnCount; }
+	}
+
+	property float SpawnRadius
+	{
+		public get() { SF2BossMakerEntityData entData; SF2BossMakerEntityData_Get(this.EntRef, entData); return entData.SpawnRadius; }
+	}
+
+	property int MaxLiveBosses
+	{
+		public get() { SF2BossMakerEntityData entData; SF2BossMakerEntityData_Get(this.EntRef, entData); return entData.MaxLiveBosses; }
+	}
+
+	property int SpawnDestination
+	{
+		public get() { SF2BossMakerEntityData entData; SF2BossMakerEntityData_Get(this.EntRef, entData); return entData.SpawnDestination; }
+		public set(int entity)
+		{ 
+			SF2BossMakerEntityData entData; SF2BossMakerEntityData_Get(this.EntRef, entData);
+			if (!IsValidEntity(entity)) 
+			{
+				entData.SpawnDestination = INVALID_ENT_REFERENCE;
+				SF2BossMakerEntityData_Update(entData);
+				return;
+			}
+
+			entData.SpawnDestination = EnsureEntRef(entity);
+			SF2BossMakerEntityData_Update(entData);
+		}
+	}
+
+	public void GetSpawnDestinationName(char[] sBuffer, int iBufferLen)
+	{
+		SF2BossMakerEntityData entData; SF2BossMakerEntityData_Get(this.EntRef, entData); 
+		strcopy(sBuffer, iBufferLen, entData.SpawnDestinationName);
+	}
+
+	public void GetSpawnAnimation(char[] sBuffer, int iBufferLen)
+	{
+		SF2BossMakerEntityData entData; SF2BossMakerEntityData_Get(this.EntRef, entData); 
+		strcopy(sBuffer, iBufferLen, entData.SpawnAnimation);
+	}
+
+	property int LiveCount
+	{
+		public get() 
+		{ 
+			SF2BossMakerEntityData entData; 
+			SF2BossMakerEntityData_Get(this.EntRef, entData);
+			
+			// Prune the list of invalid IDs.
+			ArrayList bossIds = entData.Bosses;
+			for (int i = bossIds.Length - 1; i >= 0; i--)
+			{
+				int iBossID = bossIds.Get(i);
+				int iBossIndex = NPCGetFromUniqueID(iBossID);
+				if (!NPCIsValid(iBossIndex))
+					bossIds.Erase(i);
+			}
+
+			return bossIds.Length; 
+		}
+	}
+
+	public void SpawnBoss(int iBossIndex)
+	{
+		if (!NPCIsValid(iBossIndex))
+			return;
+		
+		SF2BossMakerEntityData entData; 
+		SF2BossMakerEntityData_Get(this.EntRef, entData);
+
+		float flPos[3]; float flAng[3];
+
+		int iSpawnDestination = entData.SpawnDestination;
+		if (IsValidEntity(iSpawnDestination))
+		{
+			GetEntPropVector(iSpawnDestination, Prop_Data, "m_vecAbsOrigin", flPos);
+			GetEntPropVector(iSpawnDestination, Prop_Data, "m_angAbsRotation", flAng);
+		}
+		else 
+		{
+			GetEntPropVector(this.EntRef, Prop_Data, "m_vecAbsOrigin", flPos);
+			GetEntPropVector(this.EntRef, Prop_Data, "m_angAbsRotation", flAng);
+		}
+
+		int iSpawnFlags = GetEntProp(this.EntRef, Prop_Data, "m_spawnflags");
+
+		float flSpawnRadius = this.SpawnRadius;
+		if (flSpawnRadius > 0.0)
+		{
+			float flRad = GetRandomFloat(0.0, 2.0 * FLOAT_PI);
+			float flRadius = GetRandomFloat(0.0, flSpawnRadius);
+			float flVec[3];
+			flVec[0] = Cosine(flRad) * flRadius; 
+			flVec[1] = Sine(flRad) * flRadius;
+
+			flPos[0] += flVec[0];
+			flPos[1] += flVec[1];
+		}
+
+		SpawnSlender(view_as<SF2NPC_BaseNPC>(iBossIndex), flPos);
+
+		int iBossEntIndex = NPCGetEntIndex(iBossIndex);
+		if (IsValidEntity(iBossEntIndex))
+		{
+			if (!(iSpawnFlags & SF_SF2_BOSS_MAKER_NODROP))
+			{
+				// Drop (teleport) it to the ground.
+
+				float flMins[3]; float flMaxs[3];
+				GetEntPropVector(iBossEntIndex, Prop_Data, "m_vecAbsOrigin", flPos);
+				GetEntPropVector(iBossEntIndex, Prop_Send, "m_vecMins", flMins);
+				GetEntPropVector(iBossEntIndex, Prop_Send, "m_vecMaxs", flMaxs);
+
+				float flEndPos[3];
+				flEndPos[0] = flPos[0];
+				flEndPos[1] = flPos[1];
+				flEndPos[2] = flPos[2] - 1024.0;
+
+				Handle hTrace = TR_TraceHullFilterEx(flPos, flEndPos, flMins, flMaxs, MASK_PLAYERSOLID_BRUSHONLY, TraceRayDontHitEntity, iBossEntIndex);
+				bool bTraceHit = TR_DidHit(hTrace);
+				TR_GetEndPosition(flEndPos, hTrace);
+				delete hTrace;
+
+				if (bTraceHit)
+				{
+					TeleportEntity(iBossEntIndex, flEndPos, NULL_VECTOR, NULL_VECTOR);
+				}
+			}
+
+			if (NPCGetType(iBossIndex) == SF2BossType_Chaser && entData.SpawnAnimation[0] != '\0')
+			{
+				float flPlaybackRate = entData.SpawnAnimationPlaybackRate;
+				float flDuration = entData.SpawnAnimationDuration;
+
+				EntitySetAnimation(iBossEntIndex, entData.SpawnAnimation, flPlaybackRate);
+				EntitySetAnimation(iBossEntIndex, entData.SpawnAnimation, flPlaybackRate); //Fix an issue where an anim could start on the wrong frame.
+
+				g_bSlenderSpawning[iBossIndex] = true;
+				g_hSlenderSpawnTimer[iBossIndex] = CreateTimer(flDuration, Timer_SlenderSpawnTimer, EntIndexToEntRef(iBossEntIndex), TIMER_FLAG_NO_MAPCHANGE);
+				g_hSlenderEntityThink[iBossIndex] = null;
+			}
+
+			this.FireOutputNoVariant("OnSpawn", iBossEntIndex, this.EntRef);
+		}
+	}
+
+	public void RespawnAllChildren()
+	{
+		SF2BossMakerEntityData entData; 
+		SF2BossMakerEntityData_Get(this.EntRef, entData);
+
+		ArrayList bossIds = entData.Bosses; 
+		for (int i = bossIds.Length - 1; i >= 0; i--)
+		{
+			int iBossID = bossIds.Get(i);
+			int iBossIndex = NPCGetFromUniqueID(iBossID);
+			if (!NPCIsValid(iBossIndex))
+			{
+				bossIds.Erase(i);
+				continue;
+			}
+
+			this.SpawnBoss(iBossIndex);
+		}
+	}
+
+	public void DespawnAllChildren()
+	{
+		SF2BossMakerEntityData entData; 
+		SF2BossMakerEntityData_Get(this.EntRef, entData);
+
+		ArrayList bossIds = entData.Bosses; 
+		for (int i = bossIds.Length - 1; i >= 0; i--)
+		{
+			int iBossID = bossIds.Get(i);
+			int iBossIndex = NPCGetFromUniqueID(iBossID);
+			if (!NPCIsValid(iBossIndex))
+			{
+				bossIds.Erase(i);
+				continue;
+			}
+
+			RemoveSlender(iBossIndex);
+		}
+	}
+
+	public void RemoveAllChildren()
+	{
+		SF2BossMakerEntityData entData; 
+		SF2BossMakerEntityData_Get(this.EntRef, entData);
+
+		ArrayList bossIds = entData.Bosses; 
+		for (int i = bossIds.Length - 1; i >= 0; i--)
+		{
+			int iBossID = bossIds.Get(i);
+			int iBossIndex = NPCGetFromUniqueID(iBossID);
+			if (!NPCIsValid(iBossIndex))
+				continue;
+
+			RemoveProfile(iBossIndex);
+		}
+
+		bossIds.Clear();
+	}
+
+	public void Spawn()
+	{
+		char sTargetProfile[SF2_MAX_PROFILE_NAME_LENGTH];
+		this.GetBossProfile(sTargetProfile, sizeof(sTargetProfile));
+		if (sTargetProfile[0] == '\0')
+		{
+			PrintToServer("%s tried to spawn with blank profile", g_sEntityClassname);
+			return;
+		}
+
+		int iLiveCount = this.LiveCount;
+
+		if (this.MaxLiveBosses != -1 && iLiveCount >= this.MaxLiveBosses)
+			return; // Hit limit; don't spawn.
+
+		SF2BossMakerEntityData entData; 
+		SF2BossMakerEntityData_Get(this.EntRef, entData);
+
+		int iSpawnFlags = GetEntProp(this.EntRef, Prop_Data, "m_spawnflags");
+
+		// Calculate the spawn destination.
+		if (!(iSpawnFlags & SF_SF2_BOSS_MAKER_ADDONLY) && entData.SpawnDestinationName[0] != '\0')
+		{
+			int iSpawnDestination = entData.SpawnDestination;
+			if (!IsValidEntity(iSpawnDestination))
+			{
+				// Find the spawn destination entity and cache it.
+				int target = -1;
+				while ((target = SF2MapEntity_FindEntityByTargetname(target, entData.SpawnDestinationName, this.EntRef, this.EntRef, this.EntRef)) != -1)
+				{
+					if (!IsValidEntity(target))
+						continue;
+					
+					iSpawnDestination = EnsureEntRef(target);
+					entData.SpawnDestination = target;
+					SF2BossMakerEntityData_Update(entData);
+
+					break;
+				}
+			}
+		}
+
+		int iMaxCount = this.SpawnCount;
+		if (this.MaxLiveBosses != -1)
+		{
+			int iMaxCanSpawnCount = this.MaxLiveBosses - iLiveCount;
+			iMaxCount = iMaxCount > iMaxCanSpawnCount ? iMaxCanSpawnCount : iMaxCount;
+		}
+
+		int iBossFlags = 0;
+		if (iSpawnFlags & SF_SF2_BOSS_MAKER_FAKE)
+			iBossFlags |= SFF_FAKE;
+		if (iSpawnFlags & SF_SF2_BOSS_MAKER_NOTELEPORT)
+			iBossFlags |= SFF_NOTELEPORT;
+		if (iSpawnFlags & SF_SF2_BOSS_MAKER_ATTACKWAITERS)
+			iBossFlags |= SFF_ATTACKWAITERS;
+
+		bool bSpawnCompanions = true;
+		bool bPlaySpawnSound = true;
+		if (iSpawnFlags & SF_SF2_BOSS_MAKER_NOCOMPANIONS)
+			bSpawnCompanions = false;
+		if (iSpawnFlags & SF_SF2_BOSS_MAKER_NOSPAWNSOUND)
+			bPlaySpawnSound = false;
+
+		for (int i = 0; i < iMaxCount; i++)
+		{
+			int iBossIndex = view_as<int>(AddProfile(sTargetProfile, iBossFlags, _, bSpawnCompanions, bPlaySpawnSound));
+			if (!NPCIsValid(iBossIndex))
+				continue;
+
+			entData.Bosses.Push(NPCGetUniqueID(iBossIndex));
+
+			if ((iSpawnFlags & SF_SF2_BOSS_MAKER_NOCOPIES))
+				NPCSetFlags(iBossIndex, NPCGetFlags(iBossIndex) & ~SFF_COPIES);
+
+			if (!(iSpawnFlags & SF_SF2_BOSS_MAKER_ADDONLY))
+			{
+				this.SpawnBoss(iBossIndex);
+			}
+		}
+	}
+}
+
+void SF2BossMakerEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2BossMakerEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2BossMakerEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2BossMakerEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2BossMakerEntity_OnEntityDestroyed);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2BossMakerEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2BossMakerEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2BossMakerEntity_OnLevelInit);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2BossMakerEntity_OnMapStart);
+}
+
+static void SF2BossMakerEntity_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2BossMakerEntity_OnMapStart() 
+{
+}
+
+static void SF2BossMakerEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2BossMakerEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2BossMakerEntity_SpawnPost);
+}
+
+static Action SF2BossMakerEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2BossMakerEntityData entData;
+	int iIndex = SF2BossMakerEntityData_Get(entity, entData);
+	if (iIndex == -1)
+		return Plugin_Continue;
+	
+	SF2BossMakerEntity spawnPoint = SF2BossMakerEntity(entity);
+
+	if (strcmp(szKeyName, "profile", false) == 0)
+	{
+		entData.SetBossProfile(szValue);
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "spawncount", false) == 0)
+	{
+		int iValue = StringToInt(szValue);
+		if (iValue < 0)
+			iValue = 0;
+
+		entData.SpawnCount = iValue;
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "spawnradius", false) == 0)
+	{
+		float flValue = StringToFloat(szValue);
+		if (flValue < 0.0)
+			flValue = 0.0;
+
+		entData.SpawnRadius = flValue;
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "maxlive", false) == 0)
+	{
+		entData.MaxLiveBosses = StringToInt(szValue);
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "spawndestination", false) == 0)
+	{
+		entData.SetSpawnDestinationName(szValue);
+		entData.SpawnDestination = INVALID_ENT_REFERENCE; // mark as dirty.
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "spawnanim", false) == 0)
+	{
+		entData.SetSpawnAnimation(szValue);
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "spawnanimrate", false) == 0)
+	{
+		entData.SpawnAnimationPlaybackRate = StringToFloat(szValue);
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "spawnanimtime", false) == 0)
+	{
+		entData.SpawnAnimationDuration = StringToFloat(szValue);
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "OnSpawn", false) == 0)
+	{
+		spawnPoint.AddOutput(szKeyName, szValue);
+
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static Action SF2BossMakerEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2BossMakerEntityData entData;
+	int iIndex = SF2BossMakerEntityData_Get(entity, entData);
+	if (iIndex == -1)
+		return Plugin_Continue;
+	
+	SF2BossMakerEntity spawnPoint = SF2BossMakerEntity(entity);
+
+	if (strcmp(szInputName, "Spawn", false) == 0)
+	{
+		spawnPoint.Spawn();
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "RespawnAll", false) == 0)
+	{
+		spawnPoint.RespawnAllChildren();
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "DespawnAll", false) == 0)
+	{
+		spawnPoint.DespawnAllChildren();
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "RemoveAll", false) == 0)
+	{
+		spawnPoint.RemoveAllChildren();
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetSpawnRadius", false) == 0)
+	{
+		entData.SpawnRadius = SF2MapEntity_GetFloatFromVariant();
+		if (entData.SpawnRadius < 0.0) entData.SpawnRadius = 0.0;
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetMaxLiveChildren", false) == 0)
+	{
+		entData.MaxLiveBosses = SF2MapEntity_GetIntFromVariant();
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetSpawnDestination", false) == 0)
+	{
+		char sDestinationName[64];
+		SF2MapEntity_GetStringFromVariant(sDestinationName, sizeof(sDestinationName));
+
+		entData.SetSpawnDestinationName(sDestinationName);
+		entData.SpawnDestination = INVALID_ENT_REFERENCE; // mark as dirty.
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetBossProfile", false) == 0)
+	{
+		char sProfile[SF2_MAX_PROFILE_NAME_LENGTH];
+		SF2MapEntity_GetStringFromVariant(sProfile, sizeof(sProfile));
+
+		entData.SetBossProfile(sProfile);
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetSpawnAnimation", false) == 0)
+	{
+		char sAnimation[64];
+		SF2MapEntity_GetStringFromVariant(sAnimation, sizeof(sAnimation));
+
+		entData.SetSpawnAnimation(sAnimation);
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetSpawnAnimationPlaybackRate", false) == 0)
+	{
+		entData.SpawnAnimationPlaybackRate = SF2MapEntity_GetFloatFromVariant();
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+	else if (strcmp(szInputName, "SetSpawnAnimationDuration", false) == 0)
+	{
+		entData.SpawnAnimationDuration = SF2MapEntity_GetFloatFromVariant();
+		SF2BossMakerEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+static void SF2BossMakerEntity_SpawnPost(int entity) 
+{
+}
+
+static void SF2BossMakerEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2BossMakerEntityData entData;
+	int iIndex = SF2BossMakerEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2BossMakerEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2BossMakerEntityData_Get(int entIndex, SF2BossMakerEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+static int SF2BossMakerEntityData_Update(SF2BossMakerEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_info_boss_spawn.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_info_boss_spawn.sp
@@ -71,7 +71,7 @@ methodmap SF2BossSpawnEntity < SF2MapEntity
 		char sProfile[SF2_MAX_PROFILE_NAME_LENGTH];
 
 		float flPos[3];
-		GetEntPropVector(this.EntRef, Prop_Data, "m_vecOrigin", flPos);
+		GetEntPropVector(this.EntRef, Prop_Data, "m_vecAbsOrigin", flPos);
 
 		int iCount = 0;
 		int iMaxCount = this.MaxBosses;

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_info_boss_spawn.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_info_boss_spawn.sp
@@ -70,8 +70,9 @@ methodmap SF2BossSpawnEntity < SF2MapEntity
 
 		char sProfile[SF2_MAX_PROFILE_NAME_LENGTH];
 
-		float flPos[3];
+		float flPos[3]; float flAng[3];
 		GetEntPropVector(this.EntRef, Prop_Data, "m_vecAbsOrigin", flPos);
+		GetEntPropVector(this.EntRef, Prop_Data, "m_angAbsRotation", flAng);
 
 		int iCount = 0;
 		int iMaxCount = this.MaxBosses;
@@ -87,7 +88,12 @@ methodmap SF2BossSpawnEntity < SF2MapEntity
 				SpawnSlender(view_as<SF2NPC_BaseNPC>(iBossIndex), flPos);
 				iCount++;
 
-				this.FireOutputNoVariant("OnSpawn", NPCGetEntIndex(iBossIndex), this.EntRef);
+				int iBossEntIndex = NPCGetEntIndex(iBossIndex);
+				if (IsValidEntity(iBossEntIndex))
+				{
+					TeleportEntity(iBossEntIndex, NULL_VECTOR, flAng, NULL_VECTOR);
+					this.FireOutputNoVariant("OnSpawn", iBossEntIndex, this.EntRef);
+				}
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_info_page_spawn.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_info_page_spawn.sp
@@ -16,6 +16,7 @@ enum struct SF2PageSpawnEntityData
 	float ModelScale;
 	char Group[64];
 	char Animation[64];
+	char CollectSound[PLATFORM_MAX_PATH];
 
 	// renderamt, rendermode, and rendercolor are properties of CBaseEntity and
 	// thus do not need to be saved here.
@@ -23,11 +24,12 @@ enum struct SF2PageSpawnEntityData
 	void Init(int entIndex)
 	{
 		this.EntRef = EnsureEntRef(entIndex);
-		strcopy(this.Model, PLATFORM_MAX_PATH, "models/slender/sheet.mdl");
+		strcopy(this.Model, PLATFORM_MAX_PATH, PAGE_MODEL);
 		this.Skin = -1;
 		this.ModelScale = 1.0;
 		this.Group[0] = '\0';
 		this.Animation[0] = '\0';
+		this.CollectSound[0] = '\0';
 	}
 
 	void SetModel(const char[] sModel)
@@ -43,6 +45,11 @@ enum struct SF2PageSpawnEntityData
 	void SetAnimation(const char[] sAnimation)
 	{
 		strcopy(this.Animation, 64, sAnimation);
+	}
+
+	void SetCollectSound(const char[] sSound)
+	{
+		strcopy(this.CollectSound, PLATFORM_MAX_PATH, sSound);
 	}
 
 	void Destroy()
@@ -92,6 +99,12 @@ methodmap SF2PageSpawnEntity < SF2MapEntity
 	{
 		SF2PageSpawnEntityData entData; SF2PageSpawnEntityData_Get(this.EntRef, entData);
 		strcopy(sBuffer, iBufferLen, entData.Animation);
+	}
+
+	public void GetCollectSound(char[] sBuffer, int iBufferLen)
+	{
+		SF2PageSpawnEntityData entData; SF2PageSpawnEntityData_Get(this.EntRef, entData);
+		strcopy(sBuffer, iBufferLen, entData.CollectSound);
 	}
 
 	public void GetRenderColor(int& r, int& g, int& b, int& a)
@@ -190,6 +203,13 @@ static Action SF2PageSpawnEntity_OnEntityKeyValue(int entity, const char[] sClas
 
 		return Plugin_Handled;
 	}
+	else if (strcmp(szKeyName, "collectsound", false) == 0)
+	{
+		entData.SetCollectSound(szValue);
+		SF2PageSpawnEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
 
 	return Plugin_Continue;
 }
@@ -208,6 +228,9 @@ static void SF2PageSpawnEntity_SpawnPost(int entity)
 
 	if (entData.Model[0] != '\0')
 		PrecacheModel(entData.Model); // Precache, or else...
+
+	if (entData.CollectSound[0] != '\0')
+		PrecacheSound(entData.CollectSound); // Precache, or else...
 }
 
 static void SF2PageSpawnEntity_OnEntityDestroyed(int entity, const char[] sClass)

--- a/addons/sourcemod/scripting/sf2/npc.sp
+++ b/addons/sourcemod/scripting/sf2/npc.sp
@@ -1826,8 +1826,8 @@ void SpawnSlender(SF2NPC_BaseNPC Npc, const float pos[3])
 			for (int iDifficulty2 = 0; iDifficulty2 < Difficulty_Max; iDifficulty2++)
 			{
 				g_flSlenderTimeUntilKill[iBossIndex] = GetGameTime() + NPCGetIdleLifetime(iBossIndex, iDifficulty2);
-				float flMin = GetChaserProfileWanderTimeMin(iBossIndex, iDifficulty2);
-				float flMax = GetChaserProfileWanderTimeMax(iBossIndex, iDifficulty2);
+				float flMin = GetChaserProfileWanderTimeMin(NPCGetUniqueProfileIndex(iBossIndex), iDifficulty2);
+				float flMax = GetChaserProfileWanderTimeMax(NPCGetUniqueProfileIndex(iBossIndex), iDifficulty2);
 				g_flSlenderNextWanderPos[iBossIndex][iDifficulty2] = GetGameTime() + GetRandomFloat(flMin, flMax);
 			}
 			

--- a/addons/sourcemod/scripting/sf2/npc/npc_chaser.sp
+++ b/addons/sourcemod/scripting/sf2/npc/npc_chaser.sp
@@ -4032,8 +4032,8 @@ public Action Timer_SlenderChaseBossThink(Handle timer, any entref)
 			{
 				if (GetGameTime() >= g_flSlenderNextWanderPos[iBossIndex][iDifficulty])
 				{
-					float flMin = GetChaserProfileWanderTimeMin(iBossIndex, iDifficulty);
-					float flMax = GetChaserProfileWanderTimeMax(iBossIndex, iDifficulty);
+					float flMin = GetChaserProfileWanderTimeMin(NPCGetUniqueProfileIndex(iBossIndex), iDifficulty);
+					float flMax = GetChaserProfileWanderTimeMax(NPCGetUniqueProfileIndex(iBossIndex), iDifficulty);
 					g_flSlenderNextWanderPos[iBossIndex][iDifficulty] = GetGameTime() + GetRandomFloat(flMin, flMax);
 					
 					if (NPCGetFlags(iBossIndex) & SFF_WANDERMOVE)

--- a/sf2.fgd
+++ b/sf2.fgd
@@ -41,7 +41,7 @@
 		1 : "Yes"
 	]
 
-	survive(choices) : "Survive before Escape" : 0 : "Are players required to survive before trying to escape? NOTE: If this is a Proxy Survival map (sf2_logic_proxy), this will always be Yes." =
+	survive(choices) : "Survive before Escape" : 0 : "Are players required to survive before trying to escape? NOTE: For Modified, if this is a Proxy Survival map (sf2_logic_proxy), this will always be Yes." =
 	[
 		0 : "No"
 		1 : "Yes"
@@ -67,12 +67,36 @@
 		1 : "Enabled"
 	]
 
-	bosseschaseendlessly(choices) : "Bosses Chase Endlessly" : 0 : "If enabled, bosses in the map will chase players endlessly. This is set at round start." =
+	bosseschaseendlessly(choices) : "Bosses Chase Endlessly" : 0 : "(Modified only) If enabled, bosses in the map will chase players endlessly. This is set at round start." =
 	[
 		0 : "Disabled"
 		1 : "Enabled"
 	]
 
+	unreachableescape(choices) : "Unreachable Escape" : 0 : "(Private only) Is the escape zone unreachable by players?" = 
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+
+	adventuremap(choices) : "Is Adventure Map" : 0 : "(Private only) Is this an Adventure map?" =
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+
+	classicmap(choices) : "Is Classic Map" : 0 : "(Private only) Is this a Classic map?" =
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+
+	escapemap(choices) : "Is Escape Map" : 0 : "(Private only) Is this an Escape map?" =
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+	
 	input SetTimeLimit(integer) : "Sets the maximum time of a round."
 	input SetEscapeTimeLimit(integer) : "Sets how much time players have to escape the map, if there is an escape objective."
 	input SetTime(integer) : "Sets the current round time."
@@ -88,9 +112,9 @@
 	input DisableInfiniteBlink(void) : "Disable infinite blink." 
 	input SetBossOverride(string) : "Sets the boss override."
 	input ClearBossOverride(void) : "Clears the boss override."
-	input SetDifficulty(integer) : "Sets the difficulty of the game, from Normal (1) to Apollyon (5). This will fire the OnDifficultyChanged output."
-	input EnableBossesChaseEndlessly(void) : "Enable bosses chasing players endlessly."
-	input DisableBossesChaseEndlessly(void) : "Disable bosses chasing players endlessly."
+	input SetDifficulty(integer) : "Sets the difficulty of the game, from Normal (1) to Nightmare (4), Apollyon (5) for Modified. This will fire the OnDifficultyChanged output."
+	input EnableBossesChaseEndlessly(void) : "(Modified only) Enable bosses chasing players endlessly."
+	input DisableBossesChaseEndlessly(void) : "(Modified only) Disable bosses chasing players endlessly."
 	input EndGracePeriod(void) : "Ends the grace period of the round. This will fire the OnGracePeriodEnded output."
 
 	output OnStateEnterWaiting(void) : "Sent when entering the Waiting round state."
@@ -159,13 +183,50 @@
 	input SetBossProfile(string) : "Sets the boss profile name to look for among active bosses."
 ]
 
+@PointClass base(SF2SpawnPoint) sphere(spawnradius) iconsprite("editor/npc_maker.vmt") = sf2_boss_maker : "An entity that can create and spawn bosses at its location."
+[
+	profile(string) : "Boss Profile" : "" : "The name of the boss profile to spawn."
+	spawncount(integer) : "Spawn Count" : 1 : "Amount of bosses to spawn at once."
+	spawnradius(float) : "Spawn Radius" : "0.0" : "If set, will spawn the boss in a random point located around this entity. NOTE: Bosses will spawn around in a 2D flat circle, rather than a sphere. This also does not do space checking so make sure that the entity has enough room to spawn."
+	maxlive(integer) : "Max Live Children" : -1 : "The maximum amount of bosses that can exist at once from this entity. -1 = no limit"
+	spawndestination(target_destination) : "Spawn Destination" : "" : "If set, bosses will spawn at this entity."
+	spawnanim(string) : "Spawn Animation" : "" : "If set, boss will play this animation upon spawning. Only for Chaser bosses."
+	spawnanimrate(float) : "Spawn Animation Playback Rate" : "1.0" : "The playback rate of the spawn animation."
+	spawnanimtime(float) : "Spawn Animation Duration" : "0.0" : "How long the boss should play its animation."
+
+	spawnflags(flags) =
+	[
+		1 : "Do Not Drop" : 0
+		2 : "Don't spawn - add only" : 0
+		4 : "Is Fake" : 0
+		8 : "No Teleport" : 0
+		16 : "Attack Waiters" : 0
+		32 : "No Companions" : 0
+		64 : "No Spawn Sound" : 0
+		128 : "No Copies" : 0
+	]
+
+	input Spawn(void) : "Spawns bosses at this entity. OnSpawn output is fired for each successful spawn."
+	input SetBossProfile(string) : "Sets the boss profile name to spawn."
+	input SetSpawnRadius(float) : "Sets the spawn radius of this entity."
+	input SetMaxLiveChildren(integer) : "Sets the maximum amount of bosses that can exist at once from this entity."
+	input SetSpawnDestination(string) : "Sets the spawn destination."
+	input RespawnAll(void) : "Respawns all active bosses created by this entity."
+	input DespawnAll(void) : "Despawns all bosses created by this entity."
+	input RemoveAll(void) : "Removes all bosses created by this entity."
+	input SetSpawnAnimation(string) : "Sets the spawn animation."
+	input SetSpawnAnimationPlaybackRate(float) : "Sets the spawn animation's playback rate."
+	input SetSpawnAnimationDuration(float) : "Sets the spawn animation's duration."
+]
+
 @PointClass base(Targetname, Parentname, Angles) studioprop() = sf2_info_page_spawn : "The spawn point of a page."
 [
-	model(studio) : "Model" : "models/slender/sheet.mdl" : "The world model of the page entity that spawns here."
+	model(studio) : "Model" : "models/slender/pickups/sheet.mdl" : "The world model of the page entity that spawns here."
 	skin(integer) : "Skin" : -1 : "Set this to a number other than 0 to use that skin instead of the default. Setting this to -1 will make the game iterate the skins incrementally for each page entity created."
 	modelscale(float) : "Model Scale" : "1.0" : "A multiplier for the size of the model."
 	group(string) : "Group" : "" : "The group this spawn point belongs to. When the game chooses page spawn locations, if a group is chosen, then only one spawn point in that group will be used and the rest will be ignored."
 	animation(string) : "Animation" : "" : "The animation to play for the page that spawns here."
+	collectsound(sound) : "Collect Sound" : "" : "If defined, will override sf2_gamerules's Page Collect Sound."
 
 	renderamt(integer) : "FX Amount (0 - 255)" : 255 : "The FX amount is used by the selected Render Mode."
 	rendercolor(color255) : "FX Color (R G B)" : "255 255 255" : "The FX color is used by the selected Render Mode."
@@ -184,14 +245,14 @@
 
 @PointClass base(Targetname) = sf2_info_page_music : "Entity that contains array of ranges and sounds to play during page collection."
 [
-	range1(string) : "Range 1" : "1,2" : "Specifies the collected page count range in which to play music. The range can be in one of two formats: <min>,<max> or just <num>. <min>, <max>, and <num> are integers, <min> specifies minimum collected page count while <max> specifies the maximum. Use <num> to play music only when collected page count is equal. Range 2-16 follow the same format. If you need more page ranges, create another sf2_info_page_music entity."
+	range1(string) : "Range 1" : "1,2" : "Specifies the collected page count range in which to play music. This range is inclusive. The value can be in one of two formats: <min>,<max> or just <num>. <min> specifies minimum collected page count while <max> specifies the maximum. Use <num> to play music only when collected page count is equal. Range 2-16 follow the same format. If you need more page ranges, create another of this entity."
 	music1(sound) : "Range 1 Music" : "slender/newambience_1.wav" : "Music to play when collected page count is within Range 1."
-	range2(string) : "Range 2" : "3,4" : ""
-	music2(sound) : "Range 2 Music" : "slender/newambience_2.wav" : ""
-	range3(string) : "Range 3" : "5,6" : ""
-	music3(sound) : "Range 3 Music" : "slender/newambience_3.wav" : ""
-	range4(string) : "Range 4" : "7,8" : ""
-	music4(sound) : "Range 4 Music" : "slender/newambience_4.wav" : ""
+	range2(string) : "Range 2" : "" : ""
+	music2(sound) : "Range 2 Music" : "" : ""
+	range3(string) : "Range 3" : "" : ""
+	music3(sound) : "Range 3 Music" : "" : ""
+	range4(string) : "Range 4" : "" : ""
+	music4(sound) : "Range 4 Music" : "" : ""
 	range5(string) : "Range 5" : "" : ""
 	music5(sound) : "Range 5 Music" : "" : ""
 	range6(string) : "Range 6" : "" : ""
@@ -223,11 +284,11 @@
 	]
 ]
 
-@PointClass base(Targetname) = sf2_logic_boxing : "Proxy entity for SF2 game type Boxing"
+@PointClass base(Targetname) = sf2_logic_boxing : "(Modified only) Proxy entity for SF2 game type Boxing"
 [
 ]
 
-@PointClass base(Targetname) = sf2_logic_arena : "Proxy entity for SF2 game type Arena"
+@PointClass base(Targetname) = sf2_logic_arena : "(Modified only) Proxy entity for SF2 game type Arena"
 [
 	finaletime(integer) : "Finale Time (in seconds)" : 60 : "Waves will stop advancing at this many seconds before the Escape Time runs out. This should not be greater than the Escape Time set by sf2_gamerules."
 
@@ -238,6 +299,26 @@
 	output OnWaveTriggered(integer) : "Sent when the wave changes. The current wave number is passed down as an integer."
 ]
 
-@PointClass base(Targetname) = sf2_logic_slaughter : "Proxy entity for SF2 game type Slaughter Run"
+@PointClass base(Targetname) = sf2_logic_slaughter : "(Modified only) Proxy entity for SF2 game type Slaughter Run"
+[
+]
+
+@PointClass base(Targetname) = sf2_logic_survival2 : " (Private only) Proxy entity for SF2 game type Survival 2"
+[
+]
+
+@PointClass base(Targetname) = sf2_info_jumprestrict : "(Private only) Explicitly defines setting of stamina jump restriction."
+[
+	nojumprestriction(choices) : "Stamina Jump Restriction" : 0 : "If set to Block, then players cannot jump when their Stamina is low." =
+	[
+		0 : "Block"
+		1 : "Don't Block"
+	]
+
+	input EnableStaminaJumpRestriction(void) : "Enable the stamina jump restriction."
+	input DisableStaminaJumpRestriction(void) : "Disable the stamina jump restriction."
+]
+
+@SolidClass base(trigger_multiple) = sf2_trigger_pve : "(Private only) A trigger brush that when touched by a player will enter PvE mode."
 [
 ]


### PR DESCRIPTION
Round 2. ~~Fight!~~

A much smaller update this time. These changes come after much feedback from the folks at Glub's, along with a couple of fixes found while making this PR.

# sf2_boss_maker
This adds a new entity, `sf2_boss_maker`. It is like `npc_maker` in regular HL2 maps but for bosses. It has options to set max live bosses, set an optional spawn radius for position variation, and even supports custom spawn animations, customizable with playback rate and even wait time.

Here's its entry within the .fgd:
```
profile(string) : "Boss Profile" : "" : "The name of the boss profile to spawn."
spawncount(integer) : "Spawn Count" : 1 : "Amount of bosses to spawn at once."
spawnradius(float) : "Spawn Radius" : "0.0" : "If set, will spawn the boss in a random point located around this entity. NOTE: Bosses will spawn around in a 2D flat circle, rather than a sphere. This also does not do space checking so make sure that the entity has enough room to spawn."
maxlive(integer) : "Max Live Children" : -1 : "The maximum amount of bosses that can exist at once from this entity. -1 = no limit"
spawndestination(target_destination) : "Spawn Destination" : "" : "If set, bosses will spawn at this entity."
spawnanim(string) : "Spawn Animation" : "" : "If set, boss will play this animation upon spawning. Only for Chaser bosses."
spawnanimrate(float) : "Spawn Animation Playback Rate" : "1.0" : "The playback rate of the spawn animation."
spawnanimtime(float) : "Spawn Animation Duration" : "0.0" : "How long the boss should play its animation."

spawnflags(flags) =
[
	1 : "Do Not Drop" : 0
	2 : "Don't spawn - add only" : 0
	4 : "Is Fake" : 0
	8 : "No Teleport" : 0
	16 : "Attack Waiters" : 0
	32 : "No Companions" : 0
	64 : "No Spawn Sound" : 0
	128 : "No Copies" : 0
]

input Spawn(void) : "Spawns bosses at this entity. OnSpawn output is fired for each successful spawn."
input SetBossProfile(string) : "Sets the boss profile name to spawn."
input SetSpawnRadius(float) : "Sets the spawn radius of this entity."
input SetMaxLiveChildren(integer) : "Sets the maximum amount of bosses that can exist at once from this entity."
input SetSpawnDestination(string) : "Sets the spawn destination."
input RespawnAll(void) : "Respawns all active bosses created by this entity."
input DespawnAll(void) : "Despawns all bosses created by this entity."
input RemoveAll(void) : "Removes all bosses created by this entity."
input SetSpawnAnimation(string) : "Sets the spawn animation."
input SetSpawnAnimationPlaybackRate(float) : "Sets the spawn animation's playback rate."
input SetSpawnAnimationDuration(float) : "Sets the spawn animation's duration."
```

# .fgd Changes
The .fgd file has also been updated. Some changes in the .fgd include erasing of Range 2-4's default values in `sf2_info_page_music` (hitting Apply caused the default values to reappear, which isn't ideal for maps that don't use a minimum of 4 ranges), and the addition of Private's own exclusive entities.

Both Modified and Private now share the same .fgd file, and map creators can create maps for either version, or both if desired. Information in the .fgd has been properly annotated for being either Modified or Private exclusive.

# Other Changes
- `sf2_info_page_spawn`: Added Collect Sound property. If set, will override the page collection sound defined by `sf2_gamerules`. Default model has also been changed to match the new page model.
- `sf2_info_boss_spawn`: Fixed `OnSpawn` output being fired even when the boss entity fails to spawn.
- `sf2_info_boss_spawn`: Bosses spawned with this entity will now take this entity's angles into account.
- Fixed last page music randomly playing when a boss's Chase music fades out during Escape phase, even if `sf2_escape_custommusic`/Stop Page Music On Escape is set.
- Fixed calls to `GetChaserProfileWanderTimeMin/Max` using `iBossIndex` instead of unique profile index. This may have resulted in wrong wander times being used for each boss spawned.