### PR TITLE
Map Entities Update (Round 3)

### DIFF
--- a/addons/sourcemod/scripting/sf2/mapentities.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities.sp
@@ -210,6 +210,7 @@ void SF2MapEntity_AddHook(SF2MapEntityHook hookType, Function hookFunc)
 #include "sf2/mapentities/sf2_logic_proxy.sp"
 #include "sf2/mapentities/sf2_logic_raid.sp"
 #include "sf2/mapentities/sf2_boss_maker.sp"
+#include "sf2/mapentities/sf2_trigger_boss_despawn.sp"
 
 // Modified only
 #include "sf2/mapentities/sf2_logic_arena.sp"
@@ -374,6 +375,9 @@ void SF2MapEntity_Initialize()
 
 	// sf2_boss_maker
 	SF2BossMakerEntity_Initialize();
+
+	// sf2_trigger_boss_despawn
+	SF2TriggerBossDespawnEntity_Initialize();
 
 	// Modified
 	
@@ -851,20 +855,15 @@ int SF2MapEntity_FindEntityByTargetname(int startEnt, const char[] szName, int s
 		return -1;
 	}
 
-	char sTargetName[PLATFORM_MAX_PATH];
-
 	// dear god
-
-	int iMaxEntities = GetMaxEntities() * 2; // multiply by 2 to get non-networked entities too
-	for (int i = startEnt + 1; i < iMaxEntities; i++)
+	char sTargetName[PLATFORM_MAX_PATH];
+	int ent = startEnt;
+	while ((ent = FindEntityByClassname(ent, "*")) != -1)
 	{
-		if (!IsValidEntity(i))
-			continue;
-
-		GetEntPropString(i, Prop_Data, "m_iName", sTargetName, sizeof(sTargetName));
+		GetEntPropString(ent, Prop_Data, "m_iName", sTargetName, sizeof(sTargetName));
 		if (strcmp(sTargetName, szName) == 0) 
 		{
-			return i;
+			return ent;
 		}
 	}
 

--- a/addons/sourcemod/scripting/sf2/mapentities/base.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/base.sp
@@ -51,18 +51,10 @@ void SF2MapEntityBase_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2MapEntityBase_TranslateClassname);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2MapEntityBase_InitializeEntity);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2MapEntityBase_OnEntityDestroyed);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2MapEntityBase_OnAcceptEntityInput);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2MapEntityBase_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2MapEntityBase_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2MapEntityBase_OnMapStart);
-}
-
-static void SF2MapEntityBase_OnLevelInit(const char[] sMapName) 
-{
-}
-
-static void SF2MapEntityBase_OnMapStart() 
-{
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2MapEntityBase_OnAcceptEntityInput);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2MapEntityBase_OnEntityKeyValue);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2MapEntityBase_OnLevelInit);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2MapEntityBase_OnMapStart);
 }
 
 static void SF2MapEntityBase_InitializeEntity(int entity, const char[] sClass)
@@ -75,7 +67,34 @@ static void SF2MapEntityBase_InitializeEntity(int entity, const char[] sClass)
 
 	g_EntityData.PushArray(entData, sizeof(entData));
 
-	SDKHook(entity, SDKHook_SpawnPost, SF2MapEntityBase_SpawnPost);
+	// SDKHook(entity, SDKHook_SpawnPost, SF2MapEntityBase_SpawnPost);
+}
+
+static void SF2MapEntityBase_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2MapEntityBaseData entData;
+	int iIndex = SF2MapEntityBaseData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+/*
+static void SF2MapEntityBase_SpawnPost(int entity) 
+{
+}
+
+static void SF2MapEntityBase_OnLevelInit(const char[] sMapName) 
+{
+}
+
+static void SF2MapEntityBase_OnMapStart() 
+{
 }
 
 static Action SF2MapEntityBase_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
@@ -93,24 +112,7 @@ static Action SF2MapEntityBase_OnAcceptEntityInput(int entity, const char[] sCla
 
 	return Plugin_Continue;
 }
-
-static void SF2MapEntityBase_SpawnPost(int entity) 
-{
-}
-
-static void SF2MapEntityBase_OnEntityDestroyed(int entity, const char[] sClass)
-{
-	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
-		return;
-
-	SF2MapEntityBaseData entData;
-	int iIndex = SF2MapEntityBaseData_Get(entity, entData);
-	if (iIndex != -1)
-	{
-		entData.Destroy();
-		g_EntityData.Erase(iIndex);
-	}
-}
+*/
 
 static Action SF2MapEntityBase_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
 {

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_boss_maker.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_boss_maker.sp
@@ -394,10 +394,11 @@ void SF2BossMakerEntity_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2BossMakerEntity_OnEntityDestroyed);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2BossMakerEntity_OnAcceptEntityInput);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2BossMakerEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2BossMakerEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2BossMakerEntity_OnMapStart);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2BossMakerEntity_OnLevelInit);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2BossMakerEntity_OnMapStart);
 }
 
+/*
 static void SF2BossMakerEntity_OnLevelInit(const char[] sMapName) 
 {
 }
@@ -405,6 +406,7 @@ static void SF2BossMakerEntity_OnLevelInit(const char[] sMapName)
 static void SF2BossMakerEntity_OnMapStart() 
 {
 }
+*/
 
 static void SF2BossMakerEntity_InitializeEntity(int entity, const char[] sClass)
 {
@@ -416,7 +418,7 @@ static void SF2BossMakerEntity_InitializeEntity(int entity, const char[] sClass)
 
 	g_EntityData.PushArray(entData, sizeof(entData));
 
-	SDKHook(entity, SDKHook_SpawnPost, SF2BossMakerEntity_SpawnPost);
+	//SDKHook(entity, SDKHook_SpawnPost, SF2BossMakerEntity_SpawnPost);
 }
 
 static Action SF2BossMakerEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
@@ -602,9 +604,11 @@ static Action SF2BossMakerEntity_OnAcceptEntityInput(int entity, const char[] sC
 	return Plugin_Continue;
 }
 
+/*
 static void SF2BossMakerEntity_SpawnPost(int entity) 
 {
 }
+*/
 
 static void SF2BossMakerEntity_OnEntityDestroyed(int entity, const char[] sClass)
 {

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_game_text.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_game_text.sp
@@ -8,17 +8,136 @@
 static const char g_sEntityClassname[] = "sf2_game_text";
 static const char g_sEntityTranslatedClassname[] = "game_text";
 
-void SF2GameTextEntity_Initialize() 
+static ArrayList g_EntityData;
+
+/**
+ *	Internal data stored for the entity.
+ */
+enum struct SF2GameTextEntityData
 {
-	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2GameTextEntity_TranslateClassname);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2GameTextEntity_InitializeEntity);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2GameTextEntity_OnAcceptEntityInput);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2GameTextEntity_OnMapStart);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2GameTextEntity_OnEntityDestroyed);
+	int EntRef;
+	char NextIntroTextEntityName[64];
+	float NextIntroTextDelay;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+		this.NextIntroTextEntityName[0] = '\0';
+		this.NextIntroTextDelay = 0.0;
+	}
+
+	void Destroy()
+	{
+	}
+
+	void SetNextIntroTextEntityName(const char[] sName) 
+	{
+		strcopy(this.NextIntroTextEntityName, 64, sName);
+	}
 }
 
-static void SF2GameTextEntity_OnMapStart() 
+/**
+ *	Interface that exposes public methods for interacting with the entity.
+ */
+methodmap SF2GameTextEntity < SF2MapEntity
 {
+	public SF2GameTextEntity(int entIndex) { return view_as<SF2GameTextEntity>(SF2MapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2GameTextEntityData entData;
+		return (SF2GameTextEntityData_Get(this.EntRef, entData) != -1);
+	}
+
+	public void GetMessage(char[] sBuffer, int iBufferSize)
+	{
+		GetEntPropString(this.EntRef, Prop_Data, "m_iszMessage", sBuffer, iBufferSize);
+	}
+
+	public void GetFormattedMessage(char[] sBuffer, int iBufferSize)
+	{
+		this.GetMessage(sBuffer, iBufferSize);
+
+		if (StrContains(sBuffer, "<br>") != -1)
+		{
+			ReplaceString(sBuffer, iBufferSize, "<br>", "\n");
+		}
+
+		if (StrContains(sBuffer, "<maxPages>") != -1)
+		{
+			char sArg[16]; IntToString(g_iPageMax, sArg, sizeof(sArg));
+			ReplaceString(sBuffer, iBufferSize, "<maxPages>", sArg);
+		}
+
+		if (StrContains(sBuffer, "<pageCount>") != -1)
+		{
+			char sArg[16]; IntToString(g_iPageCount, sArg, sizeof(sArg));
+			ReplaceString(sBuffer, iBufferSize, "<pageCount>", sArg);
+		}
+
+		if (StrContains(sBuffer, "<pagesLeft>") != -1)
+		{
+			char sArg[16]; IntToString(g_iPageMax - g_iPageCount, sArg, sizeof(sArg));
+			ReplaceString(sBuffer, iBufferSize, "<pagesLeft>", sArg);
+		}
+	}
+
+	/**
+	 * Gets the message formatted as an intro message.
+	 */
+	public void GetIntroMessage(char[] sBuffer, int iBufferSize)
+	{
+		this.GetFormattedMessage(sBuffer, iBufferSize);
+	}
+
+	/**
+	 * Gets the message formatted as an page collection message.
+	 */
+	public void GetPageMessage(char[] sBuffer, int iBufferSize)
+	{
+		this.GetFormattedMessage(sBuffer, iBufferSize);
+	}
+
+	/**
+	 * Gets the message formatted as an escape message.
+	 */
+	public void GetEscapeMessage(char[] sBuffer, int iBufferSize)
+	{
+		this.GetPageMessage(sBuffer, iBufferSize);
+	}
+
+	property float NextIntroTextDelay
+	{
+		public get() { SF2GameTextEntityData entData; SF2GameTextEntityData_Get(this.EntRef, entData); return entData.NextIntroTextDelay; }
+	}
+
+	property SF2GameTextEntity NextIntroTextEntity
+	{
+		public get() 
+		{  
+			SF2GameTextEntityData entData;
+			SF2GameTextEntityData_Get(this.EntRef, entData);
+
+			if (entData.NextIntroTextEntityName[0] == '\0')
+				return SF2GameTextEntity(INVALID_ENT_REFERENCE);
+
+			return SF2GameTextEntity(SF2MapEntity_FindEntityByTargetname(-1, entData.NextIntroTextEntityName, -1, -1, -1));
+		}
+	}
+}
+
+void SF2GameTextEntity_Initialize() 
+{
+	g_EntityData = new ArrayList(sizeof(SF2GameTextEntityData));
+
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2GameTextEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2GameTextEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2GameTextEntity_OnEntityKeyValue);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2GameTextEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2GameTextEntity_OnEntityDestroyed);
 }
 
 static void SF2GameTextEntity_InitializeEntity(int entity, const char[] sClass)
@@ -26,7 +145,39 @@ static void SF2GameTextEntity_InitializeEntity(int entity, const char[] sClass)
 	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
 		return;
 	
-	SDKHook(entity, SDKHook_SpawnPost, SF2GameTextEntity_SpawnPost);
+	SF2GameTextEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+}
+
+static Action SF2GameTextEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2GameTextEntityData entData;
+	if (SF2GameTextEntityData_Get(entity, entData) == -1)
+		return Plugin_Continue;
+
+	if (strcmp(szKeyName, "nextintrotextname", false) == 0) 
+	{
+		entData.SetNextIntroTextEntityName(szValue);
+		SF2GameTextEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+	else if (strcmp(szKeyName, "nextintrotextdelay", false) == 0)
+	{
+		float flDelay = StringToFloat(szValue);
+		if (flDelay < 0.0)
+			flDelay = 0.0;
+
+		entData.NextIntroTextDelay = flDelay;
+		SF2GameTextEntityData_Update(entData);
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
 }
 
 static Action SF2GameTextEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
@@ -34,13 +185,15 @@ static Action SF2GameTextEntity_OnAcceptEntityInput(int entity, const char[] sCl
 	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
 		return Plugin_Continue;
 
+	SF2GameTextEntity thisEnt = SF2GameTextEntity(entity);
+
 	if (strcmp(szInputName, "display", false) == 0)
 	{
 		int iClients[MAXPLAYERS + 1];
 		int iClientsNum;
 		
 		char sMessage[512];
-		GetEntPropString(entity, Prop_Data, "m_iszMessage", sMessage, sizeof(sMessage));
+		thisEnt.GetFormattedMessage(sMessage, sizeof(sMessage));
 
 		char sVariant[PLATFORM_MAX_PATH];
 		SF2MapEntity_GetVariantString(sVariant, sizeof(sVariant));
@@ -86,11 +239,14 @@ static void SF2GameTextEntity_OnEntityDestroyed(int entity, const char[] sClass)
 {
 	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
 		return;
-}
 
-static void SF2GameTextEntity_SpawnPost(int entity) 
-{
-	// PrintToServer("Spawned sf2_game_text entity! entity: %i", entity);
+	SF2GameTextEntityData entData;
+	int iIndex = SF2GameTextEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
 }
 
 static Action SF2GameTextEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
@@ -100,4 +256,27 @@ static Action SF2GameTextEntity_TranslateClassname(const char[] sClass, char[] s
 	
 	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
 	return Plugin_Handled;
+}
+
+static int SF2GameTextEntityData_Get(int entIndex, SF2GameTextEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+static int SF2GameTextEntityData_Update(SF2GameTextEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
 }

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_info_boss_spawn.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_info_boss_spawn.sp
@@ -108,10 +108,11 @@ void SF2BossSpawnEntity_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2BossSpawnEntity_OnEntityDestroyed);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2BossSpawnEntity_OnAcceptEntityInput);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2BossSpawnEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2BossSpawnEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2BossSpawnEntity_OnMapStart);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2BossSpawnEntity_OnLevelInit);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2BossSpawnEntity_OnMapStart);
 }
 
+/*
 static void SF2BossSpawnEntity_OnLevelInit(const char[] sMapName) 
 {
 }
@@ -119,6 +120,7 @@ static void SF2BossSpawnEntity_OnLevelInit(const char[] sMapName)
 static void SF2BossSpawnEntity_OnMapStart() 
 {
 }
+*/
 
 static void SF2BossSpawnEntity_InitializeEntity(int entity, const char[] sClass)
 {
@@ -130,7 +132,7 @@ static void SF2BossSpawnEntity_InitializeEntity(int entity, const char[] sClass)
 
 	g_EntityData.PushArray(entData, sizeof(entData));
 
-	SDKHook(entity, SDKHook_SpawnPost, SF2BossSpawnEntity_SpawnPost);
+	//SDKHook(entity, SDKHook_SpawnPost, SF2BossSpawnEntity_SpawnPost);
 }
 
 static Action SF2BossSpawnEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
@@ -204,9 +206,11 @@ static Action SF2BossSpawnEntity_OnAcceptEntityInput(int entity, const char[] sC
 	return Plugin_Continue;
 }
 
+/*
 static void SF2BossSpawnEntity_SpawnPost(int entity) 
 {
 }
+*/
 
 static void SF2BossSpawnEntity_OnEntityDestroyed(int entity, const char[] sClass)
 {

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_info_page_music.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_info_page_music.sp
@@ -172,10 +172,11 @@ void SF2PageMusicEntity_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2PageMusicEntity_OnEntityDestroyed);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2PageMusicEntity_OnAcceptEntityInput);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2PageMusicEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PageMusicEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PageMusicEntity_OnMapStart);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PageMusicEntity_OnLevelInit);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PageMusicEntity_OnMapStart);
 }
 
+/*
 static void SF2PageMusicEntity_OnLevelInit(const char[] sMapName) 
 {
 }
@@ -183,6 +184,7 @@ static void SF2PageMusicEntity_OnLevelInit(const char[] sMapName)
 static void SF2PageMusicEntity_OnMapStart() 
 {
 }
+*/
 
 static void SF2PageMusicEntity_InitializeEntity(int entity, const char[] sClass)
 {

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_info_page_spawn.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_info_page_spawn.sp
@@ -13,10 +13,12 @@ enum struct SF2PageSpawnEntityData
 	int EntRef;
 	char Model[PLATFORM_MAX_PATH];
 	int Skin;
+	int Bodygroup;
 	float ModelScale;
 	char Group[64];
 	char Animation[64];
 	char CollectSound[PLATFORM_MAX_PATH];
+	int CollectSoundPitch;
 
 	// renderamt, rendermode, and rendercolor are properties of CBaseEntity and
 	// thus do not need to be saved here.
@@ -26,10 +28,12 @@ enum struct SF2PageSpawnEntityData
 		this.EntRef = EnsureEntRef(entIndex);
 		strcopy(this.Model, PLATFORM_MAX_PATH, PAGE_MODEL);
 		this.Skin = -1;
+		this.Bodygroup = 0;
 		this.ModelScale = 1.0;
 		this.Group[0] = '\0';
 		this.Animation[0] = '\0';
 		this.CollectSound[0] = '\0';
+		this.CollectSoundPitch = 0;
 	}
 
 	void SetModel(const char[] sModel)
@@ -89,6 +93,11 @@ methodmap SF2PageSpawnEntity < SF2MapEntity
 		public get() { SF2PageSpawnEntityData entData; SF2PageSpawnEntityData_Get(this.EntRef, entData); return entData.ModelScale; }
 	}
 
+	property int Bodygroup
+	{
+		public get() { SF2PageSpawnEntityData entData; SF2PageSpawnEntityData_Get(this.EntRef, entData); return entData.Bodygroup; }
+	}
+
 	public void GetGroup(char[] sBuffer, int iBufferLen)
 	{
 		SF2PageSpawnEntityData entData; SF2PageSpawnEntityData_Get(this.EntRef, entData);
@@ -105,6 +114,11 @@ methodmap SF2PageSpawnEntity < SF2MapEntity
 	{
 		SF2PageSpawnEntityData entData; SF2PageSpawnEntityData_Get(this.EntRef, entData);
 		strcopy(sBuffer, iBufferLen, entData.CollectSound);
+	}
+
+	property int CollectSoundPitch
+	{
+		public get() { SF2PageSpawnEntityData entData; SF2PageSpawnEntityData_Get(this.EntRef, entData); return entData.CollectSoundPitch; }
 	}
 
 	public void GetRenderColor(int& r, int& g, int& b, int& a)
@@ -130,12 +144,13 @@ void SF2PageSpawnEntity_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2PageSpawnEntity_TranslateClassname);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2PageSpawnEntity_InitializeEntity);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2PageSpawnEntity_OnEntityDestroyed);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2PageSpawnEntity_OnAcceptEntityInput);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2PageSpawnEntity_OnAcceptEntityInput);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2PageSpawnEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PageSpawnEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PageSpawnEntity_OnMapStart);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PageSpawnEntity_OnLevelInit);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PageSpawnEntity_OnMapStart);
 }
 
+/*
 static void SF2PageSpawnEntity_OnLevelInit(const char[] sMapName) 
 {
 }
@@ -143,6 +158,7 @@ static void SF2PageSpawnEntity_OnLevelInit(const char[] sMapName)
 static void SF2PageSpawnEntity_OnMapStart() 
 {
 }
+*/
 
 static void SF2PageSpawnEntity_InitializeEntity(int entity, const char[] sClass)
 {
@@ -182,6 +198,11 @@ static Action SF2PageSpawnEntity_OnEntityKeyValue(int entity, const char[] sClas
 
 		return Plugin_Handled;
 	}
+	else if (strcmp(szKeyName, "setbodygroup", false) == 0)
+	{
+		entData.Bodygroup = StringToInt(szValue);
+		SF2PageSpawnEntityData_Update(entData);
+	}
 	else if (strcmp(szKeyName, "modelscale", false) == 0)
 	{
 		entData.ModelScale = StringToFloat(szValue);
@@ -210,10 +231,24 @@ static Action SF2PageSpawnEntity_OnEntityKeyValue(int entity, const char[] sClas
 
 		return Plugin_Handled;
 	}
+	else if (strcmp(szKeyName, "collectsoundpitch", false) == 0)
+	{
+		int iPitch = StringToInt(szValue);
+		if (iPitch < 0)
+			iPitch = 0;
+		else if (iPitch > 255)
+			iPitch = 255;
+
+		entData.CollectSoundPitch = iPitch;
+		SF2PageSpawnEntityData_Update(entData);
+
+		return Plugin_Handled;
+	}
 
 	return Plugin_Continue;
 }
 
+/*
 static Action SF2PageSpawnEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
 {
 	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
@@ -221,6 +256,7 @@ static Action SF2PageSpawnEntity_OnAcceptEntityInput(int entity, const char[] sC
 
 	return Plugin_Continue;
 }
+*/
 
 static void SF2PageSpawnEntity_SpawnPost(int entity) 
 {

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_info_player_escapespawn.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_info_player_escapespawn.sp
@@ -52,10 +52,11 @@ void SF2PlayerEscapeSpawnEntity_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2PlayerEscapeSpawnEntity_OnEntityDestroyed);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2PlayerEscapeSpawnEntity_OnAcceptEntityInput);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2PlayerEscapeSpawnEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PlayerEscapeSpawnEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PlayerEscapeSpawnEntity_OnMapStart);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PlayerEscapeSpawnEntity_OnLevelInit);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PlayerEscapeSpawnEntity_OnMapStart);
 }
 
+/*
 static void SF2PlayerEscapeSpawnEntity_OnLevelInit(const char[] sMapName) 
 {
 }
@@ -63,6 +64,7 @@ static void SF2PlayerEscapeSpawnEntity_OnLevelInit(const char[] sMapName)
 static void SF2PlayerEscapeSpawnEntity_OnMapStart() 
 {
 }
+*/
 
 static void SF2PlayerEscapeSpawnEntity_InitializeEntity(int entity, const char[] sClass)
 {
@@ -74,7 +76,7 @@ static void SF2PlayerEscapeSpawnEntity_InitializeEntity(int entity, const char[]
 
 	g_EntityData.PushArray(entData, sizeof(entData));
 
-	SDKHook(entity, SDKHook_SpawnPost, SF2PlayerEscapeSpawnEntity_SpawnPost);
+	//SDKHook(entity, SDKHook_SpawnPost, SF2PlayerEscapeSpawnEntity_SpawnPost);
 }
 
 static Action SF2PlayerEscapeSpawnEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
@@ -128,9 +130,11 @@ static Action SF2PlayerEscapeSpawnEntity_OnAcceptEntityInput(int entity, const c
 	return Plugin_Continue;
 }
 
+/*
 static void SF2PlayerEscapeSpawnEntity_SpawnPost(int entity) 
 {
 }
+*/
 
 static void SF2PlayerEscapeSpawnEntity_OnEntityDestroyed(int entity, const char[] sClass)
 {

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_info_player_proxyspawn.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_info_player_proxyspawn.sp
@@ -62,10 +62,11 @@ void SF2PlayerProxySpawnEntity_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2PlayerProxySpawnEntity_OnEntityDestroyed);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2PlayerProxySpawnEntity_OnAcceptEntityInput);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2PlayerProxySpawnEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PlayerProxySpawnEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PlayerProxySpawnEntity_OnMapStart);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PlayerProxySpawnEntity_OnLevelInit);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PlayerProxySpawnEntity_OnMapStart);
 }
 
+/*
 static void SF2PlayerProxySpawnEntity_OnLevelInit(const char[] sMapName) 
 {
 }
@@ -73,6 +74,7 @@ static void SF2PlayerProxySpawnEntity_OnLevelInit(const char[] sMapName)
 static void SF2PlayerProxySpawnEntity_OnMapStart() 
 {
 }
+*/
 
 static void SF2PlayerProxySpawnEntity_InitializeEntity(int entity, const char[] sClass)
 {
@@ -84,7 +86,7 @@ static void SF2PlayerProxySpawnEntity_InitializeEntity(int entity, const char[] 
 
 	g_EntityData.PushArray(entData, sizeof(entData));
 
-	SDKHook(entity, SDKHook_SpawnPost, SF2PlayerProxySpawnEntity_SpawnPost);
+	//SDKHook(entity, SDKHook_SpawnPost, SF2PlayerProxySpawnEntity_SpawnPost);
 }
 
 static Action SF2PlayerProxySpawnEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
@@ -156,9 +158,11 @@ static Action SF2PlayerProxySpawnEntity_OnAcceptEntityInput(int entity, const ch
 	return Plugin_Continue;
 }
 
+/*
 static void SF2PlayerProxySpawnEntity_SpawnPost(int entity) 
 {
 }
+*/
 
 static void SF2PlayerProxySpawnEntity_OnEntityDestroyed(int entity, const char[] sClass)
 {

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_info_player_pvpspawn.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_info_player_pvpspawn.sp
@@ -52,10 +52,11 @@ void SF2PlayerPvPSpawnEntity_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2PlayerPvPSpawnEntity_OnEntityDestroyed);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2PlayerPvPSpawnEntity_OnAcceptEntityInput);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2PlayerPvPSpawnEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PlayerPvPSpawnEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PlayerPvPSpawnEntity_OnMapStart);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2PlayerPvPSpawnEntity_OnLevelInit);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2PlayerPvPSpawnEntity_OnMapStart);
 }
 
+/*
 static void SF2PlayerPvPSpawnEntity_OnLevelInit(const char[] sMapName) 
 {
 }
@@ -63,6 +64,7 @@ static void SF2PlayerPvPSpawnEntity_OnLevelInit(const char[] sMapName)
 static void SF2PlayerPvPSpawnEntity_OnMapStart() 
 {
 }
+*/
 
 static void SF2PlayerPvPSpawnEntity_InitializeEntity(int entity, const char[] sClass)
 {
@@ -74,7 +76,7 @@ static void SF2PlayerPvPSpawnEntity_InitializeEntity(int entity, const char[] sC
 
 	g_EntityData.PushArray(entData, sizeof(entData));
 
-	SDKHook(entity, SDKHook_SpawnPost, SF2PlayerPvPSpawnEntity_SpawnPost);
+	//SDKHook(entity, SDKHook_SpawnPost, SF2PlayerPvPSpawnEntity_SpawnPost);
 }
 
 static Action SF2PlayerPvPSpawnEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
@@ -128,9 +130,11 @@ static Action SF2PlayerPvPSpawnEntity_OnAcceptEntityInput(int entity, const char
 	return Plugin_Continue;
 }
 
+/*
 static void SF2PlayerPvPSpawnEntity_SpawnPost(int entity) 
 {
 }
+*/
 
 static void SF2PlayerPvPSpawnEntity_OnEntityDestroyed(int entity, const char[] sClass)
 {

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_logic_arena.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_logic_arena.sp
@@ -73,11 +73,12 @@ void SF2LogicRenevantEntity_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2LogicRenevantEntity_OnEntityDestroyed);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicRenevantEntity_OnAcceptEntityInput);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicRenevantEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicRenevantEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicRenevantEntity_OnMapStart);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicRenevantEntity_OnLevelInit);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicRenevantEntity_OnMapStart);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnRenevantWaveTriggered, SF2LogicRenevantEntity_OnRenevantWaveTriggered);
 }
 
+/*
 static void SF2LogicRenevantEntity_OnLevelInit(const char[] sMapName) 
 {
 }
@@ -85,6 +86,7 @@ static void SF2LogicRenevantEntity_OnLevelInit(const char[] sMapName)
 static void SF2LogicRenevantEntity_OnMapStart() 
 {
 }
+*/
 
 static void SF2LogicRenevantEntity_InitializeEntity(int entity, const char[] sClass)
 {
@@ -96,7 +98,7 @@ static void SF2LogicRenevantEntity_InitializeEntity(int entity, const char[] sCl
 
 	g_EntityData.PushArray(entData, sizeof(entData));
 
-	SDKHook(entity, SDKHook_SpawnPost, SF2LogicRenevantEntity_SpawnPost);
+	//SDKHook(entity, SDKHook_SpawnPost, SF2LogicRenevantEntity_SpawnPost);
 }
 
 static Action SF2LogicRenevantEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
@@ -198,9 +200,11 @@ static Action SF2LogicRenevantEntity_OnAcceptEntityInput(int entity, const char[
 	return Plugin_Continue;
 }
 
+/*
 static void SF2LogicRenevantEntity_SpawnPost(int entity) 
 {
 }
+*/
 
 static void SF2LogicRenevantEntity_OnEntityDestroyed(int entity, const char[] sClass)
 {

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_logic_boxing.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_logic_boxing.sp
@@ -61,12 +61,13 @@ void SF2LogicBoxingEntity_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2LogicBoxingEntity_TranslateClassname);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2LogicBoxingEntity_InitializeEntity);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2LogicBoxingEntity_OnEntityDestroyed);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicBoxingEntity_OnAcceptEntityInput);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicBoxingEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicBoxingEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicBoxingEntity_OnMapStart);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicBoxingEntity_OnAcceptEntityInput);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicBoxingEntity_OnEntityKeyValue);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicBoxingEntity_OnLevelInit);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicBoxingEntity_OnMapStart);
 }
 
+/*
 static void SF2LogicBoxingEntity_OnLevelInit(const char[] sMapName) 
 {
 }
@@ -74,6 +75,7 @@ static void SF2LogicBoxingEntity_OnLevelInit(const char[] sMapName)
 static void SF2LogicBoxingEntity_OnMapStart() 
 {
 }
+*/
 
 static void SF2LogicBoxingEntity_InitializeEntity(int entity, const char[] sClass)
 {
@@ -85,9 +87,10 @@ static void SF2LogicBoxingEntity_InitializeEntity(int entity, const char[] sClas
 
 	g_EntityData.PushArray(entData, sizeof(entData));
 
-	SDKHook(entity, SDKHook_SpawnPost, SF2LogicBoxingEntity_SpawnPost);
+	//SDKHook(entity, SDKHook_SpawnPost, SF2LogicBoxingEntity_SpawnPost);
 }
 
+/*
 static Action SF2LogicBoxingEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
 {
 	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
@@ -107,6 +110,7 @@ static Action SF2LogicBoxingEntity_OnAcceptEntityInput(int entity, const char[] 
 static void SF2LogicBoxingEntity_SpawnPost(int entity) 
 {
 }
+*/
 
 static void SF2LogicBoxingEntity_OnEntityDestroyed(int entity, const char[] sClass)
 {

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_logic_proxy.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_logic_proxy.sp
@@ -61,12 +61,13 @@ void SF2LogicProxyEntity_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2LogicProxyEntity_TranslateClassname);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2LogicProxyEntity_InitializeEntity);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2LogicProxyEntity_OnEntityDestroyed);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicProxyEntity_OnAcceptEntityInput);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicProxyEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicProxyEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicProxyEntity_OnMapStart);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicProxyEntity_OnAcceptEntityInput);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicProxyEntity_OnEntityKeyValue);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicProxyEntity_OnLevelInit);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicProxyEntity_OnMapStart);
 }
 
+/*
 static void SF2LogicProxyEntity_OnLevelInit(const char[] sMapName) 
 {
 }
@@ -74,6 +75,7 @@ static void SF2LogicProxyEntity_OnLevelInit(const char[] sMapName)
 static void SF2LogicProxyEntity_OnMapStart() 
 {
 }
+*/
 
 static void SF2LogicProxyEntity_InitializeEntity(int entity, const char[] sClass)
 {
@@ -85,9 +87,10 @@ static void SF2LogicProxyEntity_InitializeEntity(int entity, const char[] sClass
 
 	g_EntityData.PushArray(entData, sizeof(entData));
 
-	SDKHook(entity, SDKHook_SpawnPost, SF2LogicProxyEntity_SpawnPost);
+	//SDKHook(entity, SDKHook_SpawnPost, SF2LogicProxyEntity_SpawnPost);
 }
 
+/*
 static Action SF2LogicProxyEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
 {
 	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
@@ -107,6 +110,7 @@ static Action SF2LogicProxyEntity_OnAcceptEntityInput(int entity, const char[] s
 static void SF2LogicProxyEntity_SpawnPost(int entity) 
 {
 }
+*/
 
 static void SF2LogicProxyEntity_OnEntityDestroyed(int entity, const char[] sClass)
 {

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_logic_raid.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_logic_raid.sp
@@ -61,12 +61,13 @@ void SF2LogicRaidEntity_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2LogicRaidEntity_TranslateClassname);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2LogicRaidEntity_InitializeEntity);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2LogicRaidEntity_OnEntityDestroyed);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicRaidEntity_OnAcceptEntityInput);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicRaidEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicRaidEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicRaidEntity_OnMapStart);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicRaidEntity_OnAcceptEntityInput);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicRaidEntity_OnEntityKeyValue);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicRaidEntity_OnLevelInit);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicRaidEntity_OnMapStart);
 }
 
+/*
 static void SF2LogicRaidEntity_OnLevelInit(const char[] sMapName) 
 {
 }
@@ -74,6 +75,7 @@ static void SF2LogicRaidEntity_OnLevelInit(const char[] sMapName)
 static void SF2LogicRaidEntity_OnMapStart() 
 {
 }
+*/
 
 static void SF2LogicRaidEntity_InitializeEntity(int entity, const char[] sClass)
 {
@@ -85,9 +87,10 @@ static void SF2LogicRaidEntity_InitializeEntity(int entity, const char[] sClass)
 
 	g_EntityData.PushArray(entData, sizeof(entData));
 
-	SDKHook(entity, SDKHook_SpawnPost, SF2LogicRaidEntity_SpawnPost);
+	//SDKHook(entity, SDKHook_SpawnPost, SF2LogicRaidEntity_SpawnPost);
 }
 
+/*
 static Action SF2LogicRaidEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
 {
 	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
@@ -107,6 +110,7 @@ static Action SF2LogicRaidEntity_OnAcceptEntityInput(int entity, const char[] sC
 static void SF2LogicRaidEntity_SpawnPost(int entity) 
 {
 }
+*/
 
 static void SF2LogicRaidEntity_OnEntityDestroyed(int entity, const char[] sClass)
 {

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_logic_slaughter.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_logic_slaughter.sp
@@ -61,12 +61,13 @@ void SF2LogicSlaughterEntity_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2LogicSlaughterEntity_TranslateClassname);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2LogicSlaughterEntity_InitializeEntity);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2LogicSlaughterEntity_OnEntityDestroyed);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicSlaughterEntity_OnAcceptEntityInput);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicSlaughterEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicSlaughterEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicSlaughterEntity_OnMapStart);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2LogicSlaughterEntity_OnAcceptEntityInput);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2LogicSlaughterEntity_OnEntityKeyValue);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2LogicSlaughterEntity_OnLevelInit);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2LogicSlaughterEntity_OnMapStart);
 }
 
+/*
 static void SF2LogicSlaughterEntity_OnLevelInit(const char[] sMapName) 
 {
 }
@@ -74,6 +75,7 @@ static void SF2LogicSlaughterEntity_OnLevelInit(const char[] sMapName)
 static void SF2LogicSlaughterEntity_OnMapStart() 
 {
 }
+*/
 
 static void SF2LogicSlaughterEntity_InitializeEntity(int entity, const char[] sClass)
 {
@@ -85,9 +87,10 @@ static void SF2LogicSlaughterEntity_InitializeEntity(int entity, const char[] sC
 
 	g_EntityData.PushArray(entData, sizeof(entData));
 
-	SDKHook(entity, SDKHook_SpawnPost, SF2LogicSlaughterEntity_SpawnPost);
+	//SDKHook(entity, SDKHook_SpawnPost, SF2LogicSlaughterEntity_SpawnPost);
 }
 
+/*
 static Action SF2LogicSlaughterEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
 {
 	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
@@ -107,6 +110,7 @@ static Action SF2LogicSlaughterEntity_OnAcceptEntityInput(int entity, const char
 static void SF2LogicSlaughterEntity_SpawnPost(int entity) 
 {
 }
+*/
 
 static void SF2LogicSlaughterEntity_OnEntityDestroyed(int entity, const char[] sClass)
 {

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_trigger_boss_despawn.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_trigger_boss_despawn.sp
@@ -1,0 +1,163 @@
+// sf2_trigger_boss_despawn
+
+// A trigger that when touched by a boss will despawn the boss from the map.
+
+static const char g_sEntityClassname[] = "sf2_trigger_boss_despawn"; // The custom classname of the entity. Should be prefixed with "sf2_"
+static const char g_sEntityTranslatedClassname[] = "trigger_multiple"; // The actual, underlying game entity that exists, like "info_target" or "game_text".
+
+static ArrayList g_EntityData;
+
+/**
+ *	Internal data stored for the entity.
+ */
+enum struct SF2TriggerBossDespawnEntityData
+{
+	int EntRef;
+
+	void Init(int entIndex)
+	{
+		this.EntRef = EnsureEntRef(entIndex);
+	}
+
+	void Destroy()
+	{
+	}
+}
+
+/**
+ *	Interface that exposes public methods for interacting with the entity.
+ */
+methodmap SF2TriggerBossDespawnEntity < SF2TriggerMapEntity
+{
+	public SF2TriggerBossDespawnEntity(int entIndex) { return view_as<SF2TriggerBossDespawnEntity>(SF2TriggerMapEntity(entIndex)); }
+
+	public bool IsValid()
+	{
+		if (!SF2MapEntity(this.EntRef).IsValid())
+			return false;
+
+		SF2TriggerBossDespawnEntityData entData;
+		return (SF2TriggerBossDespawnEntityData_Get(this.EntRef, entData) != -1);
+	}
+}
+
+void SF2TriggerBossDespawnEntity_Initialize() 
+{
+	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2TriggerBossDespawnEntity_TranslateClassname);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2TriggerBossDespawnEntity_InitializeEntity);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2TriggerBossDespawnEntity_OnEntityDestroyed);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2TriggerBossDespawnEntity_OnAcceptEntityInput);
+	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2TriggerBossDespawnEntity_OnEntityKeyValue);
+}
+
+static void SF2TriggerBossDespawnEntity_InitializeEntity(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+	
+	SF2TriggerBossDespawnEntityData entData;
+	entData.Init(entity);
+
+	g_EntityData.PushArray(entData, sizeof(entData));
+
+	SDKHook(entity, SDKHook_SpawnPost, SF2TriggerBossDespawnEntity_SpawnPost);
+	SDKHook(entity, SDKHook_StartTouchPost, SF2TriggerBossDespawnEntity_OnStartTouchPost);
+}
+
+static Action SF2TriggerBossDespawnEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	SF2TriggerBossDespawnEntity thisEnt = SF2TriggerBossDespawnEntity(entity);
+
+	if (strcmp(szKeyName, "OnDespawn", false) == 0) 
+	{
+		thisEnt.AddOutput(szKeyName, szValue);
+		return Plugin_Handled;
+	}
+
+	return Plugin_Continue;
+}
+
+/*
+static Action SF2TriggerBossDespawnEntity_OnAcceptEntityInput(int entity, const char[] sClass, const char[] szInputName, int activator, int caller)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+
+	return Plugin_Continue;
+}
+*/
+
+static void SF2TriggerBossDespawnEntity_SpawnPost(int entity) 
+{
+	int iSpawnFlags = GetEntProp(entity, Prop_Data, "m_spawnflags");
+	SetEntProp(entity, Prop_Data, "m_spawnflags", iSpawnFlags | TRIGGER_NPCS);
+}
+
+static void SF2TriggerBossDespawnEntity_OnStartTouchPost(int entity, int toucher)
+{
+	if (!g_bEnabled) return;
+
+	SF2TriggerBossDespawnEntity thisEnt = SF2TriggerBossDespawnEntity(entity);
+
+	if (thisEnt.PassesTriggerFilters(toucher))
+	{
+		int iBossIndex = NPCGetFromEntIndex(entity);
+		if (iBossIndex != -1) 
+		{
+			thisEnt.FireOutputNoVariant("OnDespawn", toucher, entity);
+
+			RemoveSlender(iBossIndex);
+		}
+	}
+}
+
+static void SF2TriggerBossDespawnEntity_OnEntityDestroyed(int entity, const char[] sClass)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return;
+
+	SF2TriggerBossDespawnEntityData entData;
+	int iIndex = SF2TriggerBossDespawnEntityData_Get(entity, entData);
+	if (iIndex != -1)
+	{
+		entData.Destroy();
+		g_EntityData.Erase(iIndex);
+	}
+}
+
+static Action SF2TriggerBossDespawnEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)
+{
+	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
+		return Plugin_Continue;
+	
+	strcopy(sBuffer, iBufferLen, g_sEntityTranslatedClassname);
+	return Plugin_Handled;
+}
+
+static int SF2TriggerBossDespawnEntityData_Get(int entIndex, SF2TriggerBossDespawnEntityData entData)
+{
+	entData.EntRef = EnsureEntRef(entIndex);
+	if (entData.EntRef == INVALID_ENT_REFERENCE)
+		return -1;
+
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return -1;
+	
+	g_EntityData.GetArray(iIndex, entData, sizeof(entData));
+	return iIndex;
+}
+
+/*
+static int SF2TriggerBossDespawnEntityData_Update(SF2TriggerBossDespawnEntityData entData)
+{
+	int iIndex = g_EntityData.FindValue(entData.EntRef);
+	if (iIndex == -1)
+		return;
+	
+	g_EntityData.SetArray(iIndex, entData, sizeof(entData));
+}
+*/

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_trigger_boss_despawn.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_trigger_boss_despawn.sp
@@ -43,6 +43,8 @@ methodmap SF2TriggerBossDespawnEntity < SF2TriggerMapEntity
 
 void SF2TriggerBossDespawnEntity_Initialize() 
 {
+	g_EntityData = new ArrayList(sizeof(SF2TriggerBossDespawnEntityData));
+
 	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2TriggerBossDespawnEntity_TranslateClassname);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2TriggerBossDespawnEntity_InitializeEntity);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2TriggerBossDespawnEntity_OnEntityDestroyed);
@@ -104,7 +106,7 @@ static void SF2TriggerBossDespawnEntity_OnStartTouchPost(int entity, int toucher
 
 	if (thisEnt.PassesTriggerFilters(toucher))
 	{
-		int iBossIndex = NPCGetFromEntIndex(entity);
+		int iBossIndex = NPCGetFromEntIndex(toucher);
 		if (iBossIndex != -1) 
 		{
 			thisEnt.FireOutputNoVariant("OnDespawn", toucher, entity);

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_trigger_escape.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_trigger_escape.sp
@@ -10,19 +10,8 @@ void SF2TriggerEscapeEntity_Initialize()
 {
 	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2TriggerEscapeEntity_TranslateClassname);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2TriggerEscapeEntity_InitializeEntity);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2TriggerEscapeEntity_OnEntityDestroyed);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2TriggerEscapeEntity_OnAcceptEntityInput);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2TriggerEscapeEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2TriggerEscapeEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2TriggerEscapeEntity_OnMapStart);
-}
-
-static void SF2TriggerEscapeEntity_OnLevelInit(const char[] sMapName) 
-{
-}
-
-static void SF2TriggerEscapeEntity_OnMapStart() 
-{
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2TriggerEscapeEntity_OnAcceptEntityInput);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2TriggerEscapeEntity_OnEntityKeyValue);
 }
 
 static void SF2TriggerEscapeEntity_InitializeEntity(int entity, const char[] sClass)
@@ -32,9 +21,9 @@ static void SF2TriggerEscapeEntity_InitializeEntity(int entity, const char[] sCl
 	
 	SDKHook(entity, SDKHook_SpawnPost, SF2TriggerEscapeEntity_SpawnPost);
 	SDKHook(entity, SDKHook_StartTouchPost, SF2TriggerEscapeEntity_OnStartTouchPost);
-	SDKHook(entity, SDKHook_EndTouchPost, SF2TriggerEscapeEntity_OnEndTouchPost);
 }
 
+/*
 static Action SF2TriggerEscapeEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
 {
 	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
@@ -50,9 +39,12 @@ static Action SF2TriggerEscapeEntity_OnAcceptEntityInput(int entity, const char[
 
 	return Plugin_Continue;
 }
+*/
 
 static void SF2TriggerEscapeEntity_SpawnPost(int entity) 
 {
+	int iSpawnFlags = GetEntProp(entity, Prop_Data, "m_spawnflags");
+	SetEntProp(entity, Prop_Data, "m_spawnflags", iSpawnFlags | TRIGGER_CLIENTS);
 }
 
 static void SF2TriggerEscapeEntity_OnStartTouchPost(int entity, int toucher)
@@ -69,17 +61,6 @@ static void SF2TriggerEscapeEntity_OnStartTouchPost(int entity, int toucher)
 			TeleportClientToEscapePoint(toucher);
 		}
 	}
-}
-
-static void SF2TriggerEscapeEntity_OnEndTouchPost(int entity, int toucher)
-{
-	if (!g_bEnabled) return;
-}
-
-static void SF2TriggerEscapeEntity_OnEntityDestroyed(int entity, const char[] sClass)
-{
-	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
-		return;
 }
 
 static Action SF2TriggerEscapeEntity_TranslateClassname(const char[] sClass, char[] sBuffer, int iBufferLen)

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_trigger_pvp.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_trigger_pvp.sp
@@ -46,18 +46,8 @@ void SF2TriggerPvPEntity_Initialize()
 	SF2MapEntity_AddHook(SF2MapEntityHook_TranslateClassname, SF2TriggerPvPEntity_TranslateClassname);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityCreated, SF2TriggerPvPEntity_InitializeEntity);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityDestroyed, SF2TriggerPvPEntity_OnEntityDestroyed);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2TriggerPvPEntity_OnAcceptEntityInput);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2TriggerPvPEntity_OnEntityKeyValue);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnLevelInit, SF2TriggerPvPEntity_OnLevelInit);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnMapStart, SF2TriggerPvPEntity_OnMapStart);
-}
-
-static void SF2TriggerPvPEntity_OnLevelInit(const char[] sMapName) 
-{
-}
-
-static void SF2TriggerPvPEntity_OnMapStart() 
-{
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnAcceptEntityInput, SF2TriggerPvPEntity_OnAcceptEntityInput);
+	//SF2MapEntity_AddHook(SF2MapEntityHook_OnEntityKeyValue, SF2TriggerPvPEntity_OnEntityKeyValue);
 }
 
 static void SF2TriggerPvPEntity_InitializeEntity(int entity, const char[] sClass)
@@ -75,6 +65,7 @@ static void SF2TriggerPvPEntity_InitializeEntity(int entity, const char[] sClass
 	SDKHook(entity, SDKHook_EndTouchPost, SF2TriggerPvPEntity_OnEndTouchPost);
 }
 
+/*
 static Action SF2TriggerPvPEntity_OnEntityKeyValue(int entity, const char[] sClass, const char[] szKeyName, const char[] szValue)
 {
 	if (strcmp(sClass, g_sEntityClassname, false) != 0) 
@@ -90,11 +81,13 @@ static Action SF2TriggerPvPEntity_OnAcceptEntityInput(int entity, const char[] s
 
 	return Plugin_Continue;
 }
+*/
 
 static void SF2TriggerPvPEntity_SpawnPost(int entity) 
 {
 	// Add physics object flag, so we can zap projectiles!
 	int flags = GetEntProp(entity, Prop_Data, "m_spawnflags");
+	flags |= TRIGGER_CLIENTS;
 	flags |= TRIGGER_EVERYTHING_BUT_PHYSICS_DEBRIS;
 	//flags |= TRIGGER_PHYSICS_OBJECTS;
 	flags |= TRIGGER_PHYSICS_DEBRIS;

--- a/addons/sourcemod/scripting/sf2/pvp.sp
+++ b/addons/sourcemod/scripting/sf2/pvp.sp
@@ -808,10 +808,11 @@ public Action Timer_TeleportPlayerToPvP(Handle timer, any userid)
 		ent = -1;
 		while ((ent = FindEntityByClassname(ent, "info_target")) != -1)
 		{
+			GetEntPropString(ent, Prop_Data, "m_iName", sName, sizeof(sName));
+
 			if (StrContains(sName, "sf2_pvp_spawnpoint", false))
 				continue;
 
-			GetEntPropString(ent, Prop_Data, "m_iName", sName, sizeof(sName));
 			GetEntPropVector(ent, Prop_Data, "m_vecAbsOrigin", flMyPos);
 
 			hSpawnPointList.Push(ent);

--- a/sf2.fgd
+++ b/sf2.fgd
@@ -5,7 +5,7 @@
 	output OnSpawn(void) : "Sent when an entity spawns at this spawnpoint. The activator is the entity that spawned."
 ]
 
-@PointClass base(Targetname) = sf2_gamerules : "Proxy entity for SF2's Gamerules"
+@PointClass base(Targetname) iconsprite("editor/sf2/sf2_gamerules.vmt") = sf2_gamerules : "Proxy entity for SF2's Gamerules"
 [
 	boss(string) : "Boss" : "" : "The main boss of the map. This is set at round start."
 
@@ -13,19 +13,27 @@
 
 	maxpages(integer) : "Max Pages" : 1 : "Maximum amount of pages to spawn in the round. This is set at round start."
 
+	pagetextname(target_destination) : "Page Text Entity" : "" : "Specifies the sf2_game_text entity to use as the message to show upon page collection."
+
 	initialtimelimit(integer) : "Time Limit (in seconds)" : 200 : "How much time the players start out with after exiting grace period. This is set at round start."
 
 	pagecollectaddtime(integer) : "Time to Add on Page Collect (in seconds)" : 30 : "How much time to add to the clock upon collecting a page. This is set at round start."
 
 	pagecollectsound(sound) : "Page Collect Sound" : "slender/slenderpagegrab.wav" : "The sound path of the sound played when collecting a page. This is set at round start."
 
+	pagecollectsoundpitch(integer) : "Page Collect Sound Pitch" : 100 : "Sound pitch, expressed as a range from 1 to 255, where 100 is the sound's default pitch."
+
 	intromusicpath(sound) : "Intro Music Path" : "slender/intro.mp3" : "The sound path to the music played during Intro phase. This is set at round start."
 
 	introfadecolor(color255) : "Intro Fade Color" : "0 0 0 255" : "The color of the fade overlayed on players during Intro phase. This is set at round start."
 
-	introfadeholdtime(float) : "Intro Fade Hold Time (in seconds)" : "9" : "The amount of time to hold the fade during Intro phase. This is set at round start."
+	introfadeholdtime(float) : "Intro Fade Hold Time (in seconds)" : "9" : "The amount of time to hold the fade during Intro phase. This determines the duration of the Intro phase. This is set at round start."
 
 	introfadetime(float) : "Intro Fade Time (in seconds)" : "1" : "The amount of time it takes to fade out during Intro phase. This is set at round start."
+
+	introtextname(target_destination) : "Intro Text Entity" : "" : "Specifies the sf2_game_text entity to use as the first intro message."
+
+	introtextdelay(float) : "Intro Text Delay" : "1.0" : "Specifies how long to wait before showing the first intro text."
 
 	escape(choices) : "Escape to Win" : 0 : "Are players required to enter an escape zone to win after collecting all pages? If not, all players will auto-escape after collecting all pages. This is set at round start." =
 	[
@@ -34,6 +42,8 @@
 	]
 
 	escapetime(integer) : "Escape Time" : 200 : "If players have to escape, how much time (in seconds) that should be given for them. This is set at round start."
+
+	escapetextname(target_destination) : "Escape Text Entity" : "" : "Specifies the sf2_game_text entity to use as the message to show upon escape."
 
 	stoppagemusiconescape(choices) : "Stop Page Music on Escape" : 0 : "Stops the page music when entering the Escape phase." = 
 	[
@@ -99,10 +109,14 @@
 	
 	input SetTimeLimit(integer) : "Sets the maximum time of a round."
 	input SetEscapeTimeLimit(integer) : "Sets how much time players have to escape the map, if there is an escape objective."
+	input SetSurviveUntilTime(integer) : "Sets time to escape after survival."
 	input SetTime(integer) : "Sets the current round time."
+	input AddTime(integer) : "Adds to the current round time."
 	input SetTimeToAddOnCollectPage(integer) : "Sets the time to add to the round when collecting a page."
 	input SetCollectedPages(integer) : "Sets the amount of pages collected. This will fire the OnCollectedPagesChanged output."
 	input AddCollectedPages(integer) : "Adds the amount of pages collected. This will fire the OnCollectedPagesChanged output."
+	input SetPageTextEntity(string) : "Sets the page message entity."
+	input SetEscapeTextEntity(string) : "Sets the escape message entity."
 	input SubtractCollectedPages(integer) : "Subtracts the amount of pages collected. This will fire the OnCollectedPagesChanged output."
 	input EnableInfiniteFlashlight(void) : "Enable infinite flashlight."
 	input DisableInfiniteFlashlight(void) : "Disable infinite flashlight."
@@ -131,10 +145,62 @@
 	output OnDifficultyChanged(integer) : "Sent when the game's difficulty is changed. The difficulty number is passed down as an integer."
 	output OnCollectedPagesChanged(integer) : "Sent when the collected page count changes. The page count is passed down as an integer."
 	output OnSurvivalComplete(void) : "Sent when round time reaches Survive Until Time during Escape phase."
+
+	output OnDifficulty0(void) : "Sent when the difficulty has been changed to Easy."
+	output OnDifficulty1(void) : "Sent when the difficulty has been changed to Normal."
+	output OnDifficulty2(void) : "Sent when the difficulty has been changed to Hardcore."
+	output OnDifficulty3(void) : "Sent when the difficulty has been changed to Insane."
+	output OnDifficulty4(void) : "Sent when the difficulty has been changed to Nightmare."
+	output OnDifficulty5(void) : "(Modified only) Sent when the difficulty has been changed to Apollyon."
+
+	output OnCollected1Page(void) : "Send when players have collected 1 page."
+	output OnCollected2Pages(void) : "Send when players have collected 2 pages."
+	output OnCollected3Pages(void) : "Send when players have collected 3 pages."
+	output OnCollected4Pages(void) : "Send when players have collected 4 pages."
+	output OnCollected5Pages(void) : "Send when players have collected 5 pages."
+	output OnCollected6Pages(void) : "Send when players have collected 6 pages."
+	output OnCollected7Pages(void) : "Send when players have collected 7 pages."
+	output OnCollected8Pages(void) : "Send when players have collected 8 pages."
+	output OnCollected9Pages(void) : "Send when players have collected 9 pages."
+	output OnCollected10Pages(void) : "Send when players have collected 10 pages."
+	output OnCollected11Pages(void) : "Send when players have collected 11 pages."
+	output OnCollected12Pages(void) : "Send when players have collected 12 pages."
+	output OnCollected13Pages(void) : "Send when players have collected 13 pages."
+	output OnCollected14Pages(void) : "Send when players have collected 14 pages."
+	output OnCollected15Pages(void) : "Send when players have collected 15 pages."
+	output OnCollected16Pages(void) : "Send when players have collected 16 pages."
+	output OnCollected17Pages(void) : "Send when players have collected 17 pages."
+	output OnCollected18Pages(void) : "Send when players have collected 18 pages."
+	output OnCollected19Pages(void) : "Send when players have collected 19 pages."
+	output OnCollected20Pages(void) : "Send when players have collected 20 pages."
+	output OnCollected21Pages(void) : "Send when players have collected 21 pages."
+	output OnCollected22Pages(void) : "Send when players have collected 22 pages."
+	output OnCollected23Pages(void) : "Send when players have collected 23 pages."
+	output OnCollected24Pages(void) : "Send when players have collected 24 pages."
+	output OnCollected25Pages(void) : "Send when players have collected 25 pages."
+	output OnCollected26Pages(void) : "Send when players have collected 26 pages."
+	output OnCollected27Pages(void) : "Send when players have collected 27 pages."
+	output OnCollected28Pages(void) : "Send when players have collected 28 pages."
+	output OnCollected29Pages(void) : "Send when players have collected 29 pages."
+	output OnCollected30Pages(void) : "Send when players have collected 30 pages."
+	output OnCollected31Pages(void) : "Send when players have collected 31 pages."
+	output OnCollected32Pages(void) : "Send when players have collected 32 pages."
 ]
 
-@PointClass base(game_text) iconsprite("editor/game_text.vmt") = sf2_game_text : "A game_text entity specialized for SF2."
+@PointClass base(game_text) iconsprite("editor/sf2/sf2_game_text.vmt") = sf2_game_text : "A game_text entity specialized for SF2."
 [
+	message(string) : "Message Text" : "" : 
+		"Message to display onscreen.\n\n"+
+		"Messages shown by this entity supports variables; the following substrings found in the message will be replaced:\n"+
+		"<br> - Line break\n"+
+		"<pageCount> - Number of pages collected so far\n" +
+		"<maxPages> - Number of pages spawned in the map\n" +
+		"<pagesLeft> - Number of pages left to collect in the map"
+	color(color255) : "Color1" : "255 255 255"
+
+	nextintrotextname(target_destination) : "Next Intro Message Text Entity" : "" : "If used in the intro sequence, specifies the next text entity to display after this one is finished."
+	nextintrotextdelay(float) : "Next Intro Text Delay" : "0.0" : "If used in the intro sequence, specifies how long to wait before showing the next text entity in the sequence after this text entity is done showing its text."
+
 	input Display(string) : "Display the message text. If targetname is provided, will show text to that entity only."
 ]
 
@@ -142,7 +208,7 @@
 [
 ]
 
-@PointClass base(SF2SpawnPoint, EnableDisable) studio("models/editor/playerstart.mdl") = sf2_info_player_escapespawn : "A spawnpoint for RED players that escape the map."
+@PointClass base(SF2SpawnPoint, EnableDisable) studio("models/editor/sf2/escapespawn.mdl") = sf2_info_player_escapespawn : "A spawnpoint for RED players that escape the map."
 [
 ]
 
@@ -150,11 +216,16 @@
 [
 ]
 
-@PointClass base(SF2SpawnPoint, EnableDisable) studio("models/editor/playerstart.mdl") = sf2_info_player_pvpspawn : "A spawnpoint for players in PvP."
+@SolidClass base(trigger_multiple) = sf2_trigger_boss_despawn : "A trigger brush that despawns bosses that enter it. Takes filters into account."
+[
+	output OnDespawn(void) : "Sent when the trigger despawns a boss, activator is the boss entity."
+]
+
+@PointClass base(SF2SpawnPoint, EnableDisable) studio("models/editor/sf2/pvpspawn.mdl") = sf2_info_player_pvpspawn : "A spawnpoint for players in PvP."
 [
 ]
 
-@PointClass base(SF2SpawnPoint, EnableDisable) studio("models/editor/playerstart.mdl") = sf2_info_player_proxyspawn : "A spawnpoint for proxies in the RED play area."
+@PointClass base(SF2SpawnPoint, EnableDisable) studio("models/editor/sf2/proxyspawn.mdl") = sf2_info_player_proxyspawn : "A spawnpoint for proxies in the RED play area."
 [
 	ignorevisibility(choices) : "Ignore Visibility" : 0 : "If visibility is ignored, then proxies can spawn here regardless if a RED player has LOS or not." =
 	[
@@ -166,11 +237,11 @@
 	input DisableIgnoreVisibility(void) : "Stops ignoring visibility checks."
 ]
 
-@PointClass base(Targetname) = sf2_logic_proxy : "Proxy entity for SF2 game type Proxy Survival"
+@PointClass base(Targetname) iconsprite("editor/sf2/sf2_logic_proxy.vmt") = sf2_logic_proxy : "Proxy entity for SF2 game type Proxy Survival"
 [
 ]
 
-@PointClass base(Targetname) = sf2_logic_raid : "Proxy entity for SF2 game type Raid"
+@PointClass base(Targetname) iconsprite("editor/sf2/sf2_logic_raid.vmt") = sf2_logic_raid : "Proxy entity for SF2 game type Raid"
 [
 ]
 
@@ -183,7 +254,7 @@
 	input SetBossProfile(string) : "Sets the boss profile name to look for among active bosses."
 ]
 
-@PointClass base(SF2SpawnPoint) sphere(spawnradius) iconsprite("editor/npc_maker.vmt") = sf2_boss_maker : "An entity that can create and spawn bosses at its location."
+@PointClass base(SF2SpawnPoint) sphere(spawnradius) iconsprite("editor/sf2/sf2_boss_maker.vmt") = sf2_boss_maker : "An entity that can create and spawn bosses at its location."
 [
 	profile(string) : "Boss Profile" : "" : "The name of the boss profile to spawn."
 	spawncount(integer) : "Spawn Count" : 1 : "Amount of bosses to spawn at once."
@@ -223,10 +294,12 @@
 [
 	model(studio) : "Model" : "models/slender/pickups/sheet.mdl" : "The world model of the page entity that spawns here."
 	skin(integer) : "Skin" : -1 : "Set this to a number other than 0 to use that skin instead of the default. Setting this to -1 will make the game iterate the skins incrementally for each page entity created."
+	setbodygroup(integer) : "Body Group" : 0 : ""
 	modelscale(float) : "Model Scale" : "1.0" : "A multiplier for the size of the model."
 	group(string) : "Group" : "" : "The group this spawn point belongs to. When the game chooses page spawn locations, if a group is chosen, then only one spawn point in that group will be used and the rest will be ignored."
 	animation(string) : "Animation" : "" : "The animation to play for the page that spawns here."
 	collectsound(sound) : "Collect Sound" : "" : "If defined, will override sf2_gamerules's Page Collect Sound."
+	collectsoundpitch(integer) : "Collect Sound Pitch" : 0 : "Collect sound pitch, expressed as a range from 1 to 255, where 100 is the sound's default pitch. If set to > 0, will override sf2_gamerules's Page Collect Sound Pitch."
 
 	renderamt(integer) : "FX Amount (0 - 255)" : 255 : "The FX amount is used by the selected Render Mode."
 	rendercolor(color255) : "FX Color (R G B)" : "255 255 255" : "The FX color is used by the selected Render Mode."
@@ -243,7 +316,7 @@
 	]
 ]
 
-@PointClass base(Targetname) = sf2_info_page_music : "Entity that contains array of ranges and sounds to play during page collection."
+@PointClass base(Targetname) iconsprite("editor/sf2/sf2_info_page_music.vmt") = sf2_info_page_music : "Entity that contains array of ranges and sounds to play during page collection."
 [
 	range1(string) : "Range 1" : "1,2" : "Specifies the collected page count range in which to play music. This range is inclusive. The value can be in one of two formats: <min>,<max> or just <num>. <min> specifies minimum collected page count while <max> specifies the maximum. Use <num> to play music only when collected page count is equal. Range 2-16 follow the same format. If you need more page ranges, create another of this entity."
 	music1(sound) : "Range 1 Music" : "slender/newambience_1.wav" : "Music to play when collected page count is within Range 1."
@@ -284,11 +357,11 @@
 	]
 ]
 
-@PointClass base(Targetname) = sf2_logic_boxing : "(Modified only) Proxy entity for SF2 game type Boxing"
+@PointClass base(Targetname) iconsprite("editor/sf2/sf2_logic_boxing.vmt") = sf2_logic_boxing : "(Modified only) Proxy entity for SF2 game type Boxing"
 [
 ]
 
-@PointClass base(Targetname) = sf2_logic_arena : "(Modified only) Proxy entity for SF2 game type Arena"
+@PointClass base(Targetname) iconsprite("editor/sf2/sf2_logic_arena.vmt") = sf2_logic_arena : "(Modified only) Proxy entity for SF2 game type Arena"
 [
 	finaletime(integer) : "Finale Time (in seconds)" : 60 : "Waves will stop advancing at this many seconds before the Escape Time runs out. This should not be greater than the Escape Time set by sf2_gamerules."
 
@@ -299,15 +372,15 @@
 	output OnWaveTriggered(integer) : "Sent when the wave changes. The current wave number is passed down as an integer."
 ]
 
-@PointClass base(Targetname) = sf2_logic_slaughter : "(Modified only) Proxy entity for SF2 game type Slaughter Run"
+@PointClass base(Targetname) iconsprite("editor/sf2/sf2_logic_slaughter.vmt") = sf2_logic_slaughter : "(Modified only) Proxy entity for SF2 game type Slaughter Run"
 [
 ]
 
-@PointClass base(Targetname) = sf2_logic_survival2 : " (Private only) Proxy entity for SF2 game type Survival 2"
+@PointClass base(Targetname) iconsprite("editor/sf2/sf2_logic_elimination.vmt") = sf2_logic_elimination : " (Private only) Proxy entity for SF2 game type Elimination"
 [
 ]
 
-@PointClass base(Targetname) = sf2_info_jumprestrict : "(Private only) Explicitly defines setting of stamina jump restriction."
+@PointClass base(Targetname) iconsprite("editor/sf2/sf2_info_jumprestrict.vmt") = sf2_info_jumprestrict : "(Private only) Explicitly defines setting of stamina jump restriction."
 [
 	nojumprestriction(choices) : "Stamina Jump Restriction" : 0 : "If set to Block, then players cannot jump when their Stamina is low." =
 	[


### PR DESCRIPTION
Final round.

## Overview
### Added features:
- Custom sound pitches for page collection sounds either via `sf2_gamerules` or individual `sf2_info_page_spawn` entities. 
- Added `sf2_trigger_boss_despawn` trigger entity; despawns any boss that enters it.
- Added Bodygroup support for page spawns (though this is a bit experimental)
- `sf2_game_text` now has variable support! More info in the variable support section below.
- Added `SetSurviveUntilTime` and `AddTime` inputs for `sf2_gamerules`
- Added `OnCollected[0-32]Pages` and `OnDifficulty[0-5]` outputs for `sf2_gamerules`
- `sf2.fgd` now uses custom made sprites and models, courtesy of @xChillax! [Link to assets](https://github.com/Mentrillum/Slender-Fortress-Modified-Versions/files/6643142/sf2fgd.zip)


### Changes:
- Page messages and intro text sequence revamp! This means that `sf2_page_message`, `sf2_intro_text_#` and `sf2_intro_message` are deprecated.
- `sf2_escape_message` is now deprecated; Use `sf2_gamerules` instead via Escape Text Entity property or the `SetEscapeTextEntity` input.
- `sf2_onpagecount_#` is now deprecated; Use `sf2_gamerules`'s `OnCollectedXPages` and `OnCollectedPagesChanged` outputs instead
- `sf2_trigger_pvp` and `sf2_trigger_escape` will automatically have the Clients spawnflag turned on upon spawning.
- Renamed `sf2_logic_survival2` to `sf2_logic_elimination`

## Variable Support for `sf2_game_text`
The `sf2_game_text` entity now supports variables in its Message property. The following variables are available to ***all*** `sf2_game_text` entities:
- `<br>` - Line break
- `<maxPages>` - Number of pages spawned in the map.
- `<pageCount>` - Number of pages collected so far.
- `<pagesLeft>` - Number of pages left to collect.

To use a variable, insert the variable name anywhere in your `sf2_game_text`'s Message. For example:

Example 1: `Collected <pageCount> out of <maxPages> pages`
Displays: `Collected 1 out of 8 pages`

Example 2: `<pageCount>? Just <pageCount>? That's not enough!`
Displays: `1? Just 1? That's not enough!`

Escaping characters is not supported.

## Page Messages Revamp
To determine a `sf2_game_text` entity to show when collecting a page, use the Page Text Entity property of `sf2_gamerules`, or the `SetPageTextEntity` input along with the Name of the entity. Changing page text entities mid-game or even upon collecting a page is allowed.

`%d` is no longer used for the revamp style. This has been deprecated in favor of the new variable system introduced.

The old formatting style posed problems for map localization because of the very specific order the numbers are passed into the string (collected page count first, then max page count). Now with the variable system, localization is now easier especially for SOV languages, as the needed variables can be switched around as needed. Stripper: Source can be used for such changes.

Moreover, the variables can be used for any `sf2_game_text` entity; regardless if they are used as a page text entity, intro text entity, or not.

These changes **DO NOT APPLY** to the old entity. If you still use the `sf2_page_message` entity, you are still restricted to using `%d` and cannot use variables.

## Intro Text Sequence Revamp
Like how page messages have been revamped, use the Intro Text Entity property of `sf2_gamerules` to determine the first intro text entity in the sequence. `sf2_game_text` entities have now been fitted with the **Next Intro Text Entity** property, which determines the next intro text entity to be shown in the intro text sequence. You are no longer restricted to a naming scheme like the old system; you can use any name you like for your text entities, just as long as they are all referenced in the correct order.

`sf2_intro_message` has been deprecated as well; if you were using a `sf2_intro_message` entity, you must now manually chain it into the intro text sequence. `sf2_intro_message` will not be used if the Intro Text Entity property is used in `sf2_gamerules`.

These changes **DO NOT APPLY** to the old entities. If you still use the `sf2_intro_text_#` or `sf2_intro_message` entities, you cannot use variables.

## Conclusion
This marks the end of revamping the map entity system from old to new. Preferably, a map should be using either only the old or the new system. Even though a mixture of both is possible, I wouldn't recommend it as you may run into unexpected problems in your map. If any maps are currently using a mixture, you can use Stripper: Source as a band-aid fix, and have future updates of the map totally convert to the new system.

Here is a final list of the entities, comparison of old -> new.

<sub>* = exclusive to Modified
** = exclusive to Private
</sub>

| Old Entity | New Entity | Changes |
| :---: | :---: | --- |
| | sf2_boss_maker | Creates bosses at its location, or a custom destination set by `SetSpawnDestination` input. Optionally can set a spawn radius.<br><br>`OnSpawn` output called for each successful spawn by this entity, `!activator` being the boss entity that spawned. |
| | sf2_game_text | Allows showing custom HUD text to the player's screen. `Display` input can now optionally take a targetname or `!activator` to show text to a specific player.<br><br>`game_text` was not usable because SF2 utilizes a lot of HUD text, and its text gets overwritten in 1/10 of a second, leading to confusion in maps that use it.<br><br>Stripper: Source can be used to replace existing `game_text` entities with `sf2_game_text` entities on existing maps, and using `game_text` is ***strongly discouraged*** for future maps. |
| | sf2_trigger_boss_despawn | A trigger brush that despawns bosses that enter it. |
| sf2_adventure_map** | sf2_gamerules | Is Adventure Map property |
| sf2_boss_override_(name) | sf2_gamerules | `SetBossOverride` and `ClearBossOverride` inputs |
| sf2_bosses_chase_endlessly* | sf2_gamerules | Bosses Chase Endlessly property and `Enable/DisableBossesChaseEndlessly` inputs |
| sf2_boxing_map* | sf2_logic_boxing | |
| sf2_boxing_boss_spawn* | | Unchanged |
| sf2_classic_map** | sf2_gamerules | Is Classic Map property |
| sf2_escape_custommusic | sf2_gamerules | Stop Page Music on Escape property |
| sf2_escape_map** | sf2_gamerules | Is Escape Map property |
| sf2_escape_message | sf2_game_text | Entity referenced by Escape Text Entity property of sf2_gamerules; can also be set using `SetEscapeTextEntity` input |
| sf2_escape_spawnpoint | sf2_info_player_escapespawn | Allows multiple instances of spawn points and `Enable`/`Disable` inputs for more control over spawn locations<br><br>`OnSpawn`  output is fired for players that spawn at the entity, `!activator` being the player. |
| sf2_escape_time_limit_# | sf2_gamerules | Escape Time Limit property and `SetEscapeTimeLimit` input |
| sf2_escape_trigger | sf2_trigger_escape | Additionally can takes filters into account |
| sf2_infiniteblink | sf2_gamerules | Infinite Blink property and `Enable/DisableInfiniteBlink` inputs |
| sf2_infiniteflashlight | sf2_gamerules | Infinite Flashlight property and `Enable/DisableInfiniteFlashlight` inputs |
| sf2_infinitesprint | sf2_gamerules | Infinite Sprint property and `Enable/DisableInfiniteSprint` inputs |
| sf2_intro_fade | sf2_gamerules | Intro Fade Color, Intro Fade Time, and Intro Fade Holdtime properties |
| sf2_intro_message |  | Deprecated |
| sf2_intro_music | sf2_gamerules | Intro Music Path property |
| sf2_intro_relay | sf2_gamerules | `OnStateEnterIntro` output |
| sf2_intro_text_# | sf2_game_text | Starting text referenced by Intro Text Entity property of sf2_gamerules; subsequent text entities referenced by Next Intro Text Entity property of sf2_game_text |
| sf2_logic_escape | sf2_gamerules | Escape to Win property<br><br>For `OnUser1` output equivalent, use `OnStateEnterEscape`. |
| sf2_maxpages_# | sf2_gamerules | Max Pages property |
| sf2_maxplayers_# | sf2_gamerules | Max Players property |
| sf2_nav_interface | | Unchanged |
| sf2_nojumprestrict** | sf2_info_jumprestrict | Allows enabling/disabling the jump restriction via Stamina Jump Restriction property and the `Enable/DisableStaminaJumpRestriction` inputs. |
| sf2_onpagecount_# | sf2_gamerules | `OnCollectedXPages` and `OnCollectedPagesChanged` outputs |
| sf2_page_model<br>sf2_page_spawnpoint | sf2_info_page_spawn | Allows ability to have different models, skin, model scale, etc. for each page spawn point, as well as specify page group via the Group property. You no longer have to guess how the page will look when spawned. Supports physics simulation in Hammer++ for ultra-realistic placement! |
| sf2_page_message | sf2_game_text | Entity referenced by Page Text Entity property of sf2_gamerules; can also be set using `SetPageTextEntity` input |
| sf2_page_music_#-# | sf2_info_page_music | Contains up to 16 different page ranges as well as their respective tracks. It also has default values filled in to showcase how the ranges should be formatted. <br><br>If you need more page ranges for whatever reason, make another of this entity. |
| sf2_page_sound | sf2_gamerules | Page Collect Sound property |
| sf2_proxy_map | sf2_logic_proxy | |
| sf2_proxy_spawnpoint | sf2_info_player_proxyspawn | `Enable`/`Disable` inputs for more control over spawn locations<br><br>`OnSpawn` output fired for players that spawn at the entity, `!activator` being the player. |
| sf2_pvp_spawnpoint | sf2_info_player_pvpspawn | `Enable`/`Disable` inputs for more control over spawn locations<br><br>`OnSpawn` output fired for players that spawn at the entity, `!activator` being the player. |
| sf2_pve_trigger** | sf2_trigger_pve | |
| sf2_pvp_trigger | sf2_trigger_pvp | |
| sf2_raid_map | sf2_logic_raid | |
| sf2_renevant_map* | sf2_logic_arena | Contains inputs for controlling waves + outputs of waves triggered and Finale Time property |
| sf2_survival2_map | sf2_logic_elimination | |
| sf2_survival_map | sf2_gamerules | Survive before Escape property |
| sf2_survival_time_limit_# | sf2_gamerules | Survive Until Time property |
| sf2_slaughterrun_map* | sf2_logic_slaughter | |
| sf2_spawn_(name) | sf2_info_boss_spawn | Spawns an active boss with the matching profile name defined in Boss Profile property. Use `Spawn` input to spawn the boss.<br><br>`OnSpawn` output fired for boss entities that spawn at the entity, `!activator` being the boss entity that spawns.  |
| sf2_time_gain_from_page_# | sf2_gamerules | Time to Add on Page Collect property and `SetTimeToAddOnCollectPage` input |
| sf2_time_limit_# | sf2_gamerules | Time Limit property and `SetTimeLimit` input |
| sf2_unreachable_escape** | sf2_gamerules | Unreachable Escape property |