### PR TITLE
Add a convar to start vote whenever mapchooser has finished a map vote.

### DIFF
--- a/addons/sourcemod/scripting/sf2/profiles.sp
+++ b/addons/sourcemod/scripting/sf2/profiles.sp
@@ -1624,6 +1624,14 @@ public Action Timer_BossPackVoteLoop(Handle timer)
 	if (timer != g_hBossPackVoteTimer || g_bBossPackVoteCompleted || g_bBossPackVoteStarted) 
 		return Plugin_Stop;
 	
+	#if defined _mapchooser_included_
+	if (HasEndOfMapVoteFinished())
+	{
+		g_hBossPackVoteTimer = INVALID_HANDLE;
+		InitiateBossPackVote(99);
+		return Plugin_Stop;
+	}
+	#endif
 	if (!NativeVotes_IsVoteInProgress())
 	{
 		g_hBossPackVoteTimer = INVALID_HANDLE;


### PR DESCRIPTION
This function requires mapchooser or mapchooser_extended. You don't have to use those plugin to compile sf2m.
sf2_boss_profile_pack_endvote_start_after_mapvote 0
Warning: Build is passed but not tested in game.