### PR TITLE
Add AFK Mode + Other Stuff

### DIFF
--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -850,6 +850,7 @@ ConVar g_cvPlayerViewbobHurtEnabled;
 ConVar g_cvPlayerViewbobSprintEnabled;
 ConVar g_cvPlayerProxyWaitTime;
 ConVar g_cvPlayerProxyAsk;
+ConVar g_cvPlayerAFKTime;
 ConVar g_cvBlockSuicideDuringRound;
 ConVar g_cvRaidMap;
 ConVar g_cvProxyMap;

--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -4547,7 +4547,7 @@ void ForceInNextPlayersInQueue(int iAmount, bool bShowMessage = false)
 		if (!hArray.Get(i, 2))
 		{
 			int iClient = hArray.Get(i);
-			if (g_bPlayerPlaying[iClient] || !g_bPlayerEliminated[iClient] || !IsClientParticipating(iClient) || g_bPlayerNoPoints[iClient] || g_bAdminNoPoints[iClient]) continue;
+			if (g_bPlayerPlaying[iClient] || !g_bPlayerEliminated[iClient] || !IsClientParticipating(iClient) || g_bAdminNoPoints[iClient]) continue;
 			
 			hPlayers.Push(iClient);
 			iAmountLeft -= 1;
@@ -4573,19 +4573,6 @@ void ForceInNextPlayersInQueue(int iAmount, bool bShowMessage = false)
 				
 				iAmountLeft -= iMemberCount;
 			}
-		}
-	}
-	
-	// Could not find anyone, see if there was people we can force in
-	for (int i = 0, iSize = hArray.Length; i < iSize && iAmountLeft > 0; i++)
-	{
-		if (!hArray.Get(i, 2))
-		{
-			int iClient = hArray.Get(i);
-			if (g_bPlayerPlaying[iClient] || !g_bPlayerEliminated[iClient] || !IsClientParticipating(iClient) || g_bAdminNoPoints[iClient]) continue;
-			
-			hPlayers.Push(iClient);
-			iAmountLeft -= 1;
 		}
 	}
 	
@@ -4620,9 +4607,12 @@ void ForceInNextPlayersInQueue(int iAmount, bool bShowMessage = false)
 public int SortQueueList(int index1, int index2, Handle array, Handle hndl)
 {
 	ArrayList aArray = view_as<ArrayList>(array);
+	
+	bool bDisabled = g_bPlayerNoPoints[aArray.Get(index1, 0)];
+	if (bDisabled != g_bPlayerNoPoints[aArray.Get(index2, 0)]) return bDisabled ? 1 : -1;
+	
 	int iQueuePoints1 = aArray.Get(index1, 1);
 	int iQueuePoints2 = aArray.Get(index2, 1);
-	
 	if (iQueuePoints1 > iQueuePoints2) return -1;
 	else if (iQueuePoints1 == iQueuePoints2) return 0;
 	return 1;

--- a/addons/sourcemod/scripting/sf2/extras/afk_mode.sp
+++ b/addons/sourcemod/scripting/sf2/extras/afk_mode.sp
@@ -3,8 +3,6 @@
 #endif
 #define _sf2_afk_mode_included
 
-#define AFK_TIME	90.0
-
 static float g_fAfkAtGameTime[MAXPLAYERS + 1];
 
 void AFK_SetTime(int iClient, bool bReset = true)
@@ -20,9 +18,13 @@ void AFK_SetTime(int iClient, bool bReset = true)
 		// Player already has their points disabled
 		g_fAfkAtGameTime[iClient] = 0.0;
 	}
+	else if(!bReset || !g_cvPlayerAFKTime.BoolValue)
+	{
+		g_fAfkAtGameTime[iClient] = 0.0;
+	}
 	else
 	{
-		g_fAfkAtGameTime[iClient] = bReset ? (GetGameTime() + AFK_TIME) : 0.0;
+		g_fAfkAtGameTime[iClient] = GetGameTime() + g_cvPlayerAFKTime.FloatValue;
 	}
 }
 

--- a/addons/sourcemod/scripting/sf2/extras/afk_mode.sp
+++ b/addons/sourcemod/scripting/sf2/extras/afk_mode.sp
@@ -1,0 +1,35 @@
+#if defined _sf2_afk_mode_included
+ #endinput
+#endif
+#define _sf2_afk_mode_included
+
+#define AFK_TIME	90.0
+
+static float g_fAfkAtGameTime[MAXPLAYERS + 1];
+
+void AFK_SetTime(int iClient, bool bReset = true)
+{
+	if (g_fAfkAtGameTime[iClient] != 0.0 && g_fAfkAtGameTime[iClient] < GetGameTime())
+	{
+		g_bPlayerNoPoints[iClient] = false;
+	}
+	
+	if (g_bPlayerNoPoints[iClient] || g_bAdminNoPoints[iClient])
+	{
+		// Player already has their points disabled
+		g_fAfkAtGameTime[iClient] = 0.0;
+	}
+	else
+	{
+		g_fAfkAtGameTime[iClient] = bReset ? (GetGameTime() + AFK_TIME) : 0.0;
+	}
+}
+
+void AFK_CheckTime(int iClient)
+{
+	if (g_fAfkAtGameTime[iClient] != 0.0 && g_fAfkAtGameTime[iClient] < GetGameTime())
+	{
+		g_bPlayerNoPoints[iClient] = true;
+		PrintCenterText(iClient, "%T", "SF2 AFK Status");
+	}
+}

--- a/addons/sourcemod/scripting/sf2/extras/afk_mode.sp
+++ b/addons/sourcemod/scripting/sf2/extras/afk_mode.sp
@@ -30,6 +30,6 @@ void AFK_CheckTime(int iClient)
 	if (g_fAfkAtGameTime[iClient] != 0.0 && g_fAfkAtGameTime[iClient] < GetGameTime())
 	{
 		g_bPlayerNoPoints[iClient] = true;
-		PrintCenterText(iClient, "%T", "SF2 AFK Status");
+		PrintCenterText(iClient, "%T", "SF2 AFK Status", iClient);
 	}
 }

--- a/addons/sourcemod/scripting/sf2/extras/afk_mode.sp
+++ b/addons/sourcemod/scripting/sf2/extras/afk_mode.sp
@@ -12,6 +12,7 @@ void AFK_SetTime(int iClient, bool bReset = true)
 	if (g_fAfkAtGameTime[iClient] != 0.0 && g_fAfkAtGameTime[iClient] < GetGameTime())
 	{
 		g_bPlayerNoPoints[iClient] = false;
+		PrintCenterText(iClient, "");
 	}
 	
 	if (g_bPlayerNoPoints[iClient] || g_bAdminNoPoints[iClient])

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -594,7 +594,14 @@ public Action OnClientSayCommand(int client, const char[] command, const char[] 
 
 			if (!bSayTeam) 
 			{
-				FakeClientCommandEx(client, "say_team %s", sArgs);
+				if (sArgs[0] != '"')	// Don't let ! commands get detected twice
+				{
+					FakeClientCommandEx(client, "say_team \"%s\"", sArgs);
+				}
+				else
+				{
+					FakeClientCommandEx(client, "say_team %s", sArgs);
+				}
 				return Plugin_Stop;
 			}
 		}

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -191,6 +191,7 @@ public void OnPluginStart()
 	RegConsoleCmd("sm_slcredits", Command_Credits);
 	RegConsoleCmd("sm_slviewbosslist", Command_BossList);
 	RegConsoleCmd("sm_slbosslist", Command_BossList);
+	RegConsoleCmd("sm_slafk", Command_NoPoints);
 	RegConsoleCmd("sm_flashlight", Command_ToggleFlashlight);
 	RegConsoleCmd("+sprint", Command_SprintOn);
 	RegConsoleCmd("-sprint", Command_SprintOff);
@@ -199,7 +200,7 @@ public void OnPluginStart()
 
 	RegAdminCmd("sm_slgroupname", Command_GroupName, ADMFLAG_SLAY); //People like to use naughty names, keep it at this for now until pre-defined group names are made
 	RegAdminCmd("sm_sf2_bosspack_vote", DevCommand_BossPackVote, ADMFLAG_CHEATS);
-	RegAdminCmd("sm_sf2_nopoints", Command_NoPoints, ADMFLAG_SLAY);
+	RegAdminCmd("sm_sf2_nopoints", Command_NoPointsAdmin, ADMFLAG_SLAY);
 	RegAdminCmd("sm_sf2_scare", Command_ClientPerformScare, ADMFLAG_SLAY);
 	RegAdminCmd("sm_sf2_spawn_boss", Command_SpawnSlender, ADMFLAG_SLAY);
 	RegAdminCmd("sm_sf2_spawn_all_bosses", Command_SpawnAllSlenders, ADMFLAG_SLAY);
@@ -340,6 +341,24 @@ public Action Command_BossList(int iClient,int args)
 	return Plugin_Handled;
 }
 
+public Action Command_NoPoints(int iClient,int args)
+{
+	if (!g_bEnabled) return Plugin_Continue;
+	if(!g_bPlayerNoPoints[iClient])
+	{
+		CPrintToChat(iClient, "%T", "SF2 AFK On");
+		g_bPlayerNoPoints[iClient] = true;
+		AFK_SetTime(iClient);
+	}
+	else
+	{
+		CPrintToChat(iClient, "%T", "SF2 AFK Off");
+		g_bPlayerNoPoints[iClient] = false;
+		AFK_SetTime(iClient);
+	}
+	return Plugin_Handled;
+}
+
 public Action Command_ToggleFlashlight(int iClient,int args)
 {
 	if (!g_bEnabled) return Plugin_Continue;
@@ -424,18 +443,20 @@ public Action DevCommand_BossPackVote(int iClient,int args)
 	return Plugin_Handled;
 }
 
-public Action Command_NoPoints(int iClient,int args)
+public Action Command_NoPointsAdmin(int iClient,int args)
 {
 	if (!g_bEnabled) return Plugin_Continue;
 	if(!g_bAdminNoPoints[iClient])
 	{
-		CPrintToChat(iClient, "{royalblue}Disabled going to RED naturally.");
+		CPrintToChat(iClient, "%T", "SF2 AFK On");
 		g_bAdminNoPoints[iClient] = true;
+		AFK_SetTime(iClient);
 	}
 	else
 	{
-		CPrintToChat(iClient, "{royalblue}Enabled going to RED naturally.");
+		CPrintToChat(iClient, "%T", "SF2 AFK Off");
 		g_bAdminNoPoints[iClient] = false;
+		AFK_SetTime(iClient);
 	}
 	return Plugin_Handled;
 }

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -136,6 +136,8 @@ public void OnPluginStart()
 	
 	g_cvPlayerProxyWaitTime = CreateConVar("sf2_player_proxy_waittime", "35", "How long (in seconds) after a player was chosen to be a Proxy must the system wait before choosing him again.");
 	g_cvPlayerProxyAsk = CreateConVar("sf2_player_proxy_ask", "0", "Set to 1 if the player can choose before becoming a Proxy, set to 0 to force.");
+	
+	g_cvPlayerAFKTime = CreateConVar("sf2_player_afk_time", "60.0", "Amount of time before a player is considered AFK, set to 0 to disable.", _, true, 0.0);
 
 	g_cvPlayerInfiniteSprintOverride = CreateConVar("sf2_player_infinite_sprint_override", "-1", "1 = infinite sprint, 0 = never have infinite sprint, -1 = let the game choose.", _, true, -1.0, true, 1.0);
 	g_cvPlayerInfiniteFlashlightOverride = CreateConVar("sf2_player_infinite_flashlight_override", "-1", "1 = infinite flashlight, 0 = never have infinite flashlight, -1 = let the game choose.", _, true, -1.0, true, 1.0);

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -446,18 +446,60 @@ public Action DevCommand_BossPackVote(int iClient,int args)
 public Action Command_NoPointsAdmin(int iClient,int args)
 {
 	if (!g_bEnabled) return Plugin_Continue;
-	if(!g_bAdminNoPoints[iClient])
+	
+	if (args < 1)
 	{
-		CPrintToChat(iClient, "%T", "SF2 AFK On", iClient);
-		g_bAdminNoPoints[iClient] = true;
+		ReplyToCommand(iClient, "Usage: sm_sf2_nopoints <name|#userid> <0/1>");
+		return Plugin_Handled;
+	}
+	
+	char arg1[32];
+	GetCmdArg(1, arg1, sizeof(arg1));
+	
+	char target_name[MAX_TARGET_LENGTH];
+	int target_list[MAXPLAYERS], target_count;
+	bool tn_is_ml;
+	
+	if ((target_count = ProcessTargetString(
+			arg1,
+			iClient,
+			target_list,
+			MAXPLAYERS,
+			0,
+			target_name,
+			sizeof(target_name),
+			tn_is_ml)) <= 0)
+	{
+		ReplyToTargetError(iClient, target_count);
+		return Plugin_Handled;
+	}
+	
+	bool bMode;
+	if (args > 2)
+	{
+		char arg2[32];
+		GetCmdArg(2, arg2, sizeof(arg2));
+		bMode = view_as<bool>(StringToInt(arg2));
+	}
+	
+	for (int i = 0; i < target_count; i++)
+	{
+		int iTarget = target_list[i];
+		if (IsClientSourceTV(iTarget)) continue;//Exclude the sourcetv bot
+		
+		g_bAdminNoPoints[iClient] = args > 1 ? bMode : !g_bAdminNoPoints[iClient];
+		if(g_bAdminNoPoints[iClient])
+		{
+			CPrintToChat(iClient, "%T", "SF2 AFK On", iClient);
+		}
+		else
+		{
+			CPrintToChat(iClient, "%T", "SF2 AFK Off", iClient);
+		}
+		
 		AFK_SetTime(iClient);
 	}
-	else
-	{
-		CPrintToChat(iClient, "%T", "SF2 AFK Off", iClient);
-		g_bAdminNoPoints[iClient] = false;
-		AFK_SetTime(iClient);
-	}
+	
 	return Plugin_Handled;
 }
 

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -346,13 +346,13 @@ public Action Command_NoPoints(int iClient,int args)
 	if (!g_bEnabled) return Plugin_Continue;
 	if(!g_bPlayerNoPoints[iClient])
 	{
-		CPrintToChat(iClient, "%T", "SF2 AFK On");
+		CPrintToChat(iClient, "%T", "SF2 AFK On", iClient);
 		g_bPlayerNoPoints[iClient] = true;
 		AFK_SetTime(iClient);
 	}
 	else
 	{
-		CPrintToChat(iClient, "%T", "SF2 AFK Off");
+		CPrintToChat(iClient, "%T", "SF2 AFK Off", iClient);
 		g_bPlayerNoPoints[iClient] = false;
 		AFK_SetTime(iClient);
 	}
@@ -448,13 +448,13 @@ public Action Command_NoPointsAdmin(int iClient,int args)
 	if (!g_bEnabled) return Plugin_Continue;
 	if(!g_bAdminNoPoints[iClient])
 	{
-		CPrintToChat(iClient, "%T", "SF2 AFK On");
+		CPrintToChat(iClient, "%T", "SF2 AFK On", iClient);
 		g_bAdminNoPoints[iClient] = true;
 		AFK_SetTime(iClient);
 	}
 	else
 	{
-		CPrintToChat(iClient, "%T", "SF2 AFK Off");
+		CPrintToChat(iClient, "%T", "SF2 AFK Off", iClient);
 		g_bAdminNoPoints[iClient] = false;
 		AFK_SetTime(iClient);
 	}

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -594,7 +594,7 @@ public Action OnClientSayCommand(int client, const char[] command, const char[] 
 
 			if (!bSayTeam) 
 			{
-				if (sArgs[0] != '!')	// Don't let ! commands get detected twice
+				if (sArgs[0] != '!' || sArgs[1] != '!')	// Don't let ! commands get detected twice
 				{
 					FakeClientCommandEx(client, "say_team \" %s\"", sArgs);
 				}

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -594,9 +594,9 @@ public Action OnClientSayCommand(int client, const char[] command, const char[] 
 
 			if (!bSayTeam) 
 			{
-				if (sArgs[0] != '"')	// Don't let ! commands get detected twice
+				if (sArgs[0] != '!')	// Don't let ! commands get detected twice
 				{
-					FakeClientCommandEx(client, "say_team \"%s\"", sArgs);
+					FakeClientCommandEx(client, "say_team \" %s\"", sArgs);
 				}
 				else
 				{

--- a/addons/sourcemod/translations/sf2.phrases.txt
+++ b/addons/sourcemod/translations/sf2.phrases.txt
@@ -675,6 +675,21 @@
 		"chi"	"你正离开PvP区域！\n假如你不回去，你会在 {1} 秒后失去你的武器！"
 	}
 
+	"SF2 AFK On"
+	{
+		"en"	"{royalblue}Disabled going to RED naturally."
+	}
+
+	"SF2 AFK Off"
+	{
+		"en"	"{royalblue}Enabled going to RED naturally."
+	}
+
+	"SF2 AFK Status"
+	{
+		"en"	"You are currently AFK, press a button to wake up."
+	}
+
 	"SF2 Enabled Hints"
 	{
 		"en"	"{lightblue}Enabled hints."


### PR DESCRIPTION
An AFK mode requested by @fearts which adds a command to disable joining RED and a detection when a player goes AFK. This will make the player last priority in the queue list so empty servers still force the player in game.

Fixed using ! commands triggering the command twice.

Allowed sm_sf2_nopoints to be able to target other players.