### PR TITLE
Allow Non-Fireable Weapons Outside PvP

### DIFF
--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -862,6 +862,7 @@ ConVar g_cvSlaughterRunMap;
 ConVar g_cvTimeEscapeSurvival;
 ConVar g_cvSlaughterRunDivisibleTime;
 ConVar g_cvUseAlternateConfigDirectory;
+ConVar g_cvPlayerKeepWeapons;
 
 ConVar g_cvRestartSession;
 bool g_bRestartSessionEnabled;

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -479,7 +479,7 @@ public Action Command_NoPointsAdmin(int iClient,int args)
 	}
 	
 	bool bMode;
-	if (args > 2)
+	if (args > 1)
 	{
 		char arg2[32];
 		GetCmdArg(2, arg2, sizeof(arg2));

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -158,13 +158,15 @@ public void OnPluginStart()
 	g_cvSlaughterRunDivisibleTime = CreateConVar("sf2_slaughterrun_divide_time", "125.0", "Determines how much the average time should be divided by in Slaughter Run, the lower the number, the longer the bosses spawn.", _, true, 0.0);
 	
 	g_cvUseAlternateConfigDirectory = CreateConVar("sf2_alternateconfigs", "0", "Set to 1 if the server should pick up the configs from data/.", _, true, 0.0, true, 1.0);
-
+	
+	g_cvPlayerKeepWeapons = CreateConVar("sf2_player_keep_weapons", "0", "Set to 1 if players can keep their non-melee weapons outside of PvP arenas.", _, true, 0.0, true, 1.0);
+	
 	g_cvRestartSession = CreateConVar("sf2_dont_touch_this", "0", "Seriously, do not touch this.", _, true, 0.0, true, 1.0);
 	g_cvRestartSession.AddChangeHook(OnConVarChanged);
-
+	
 	g_cvSurvivalMap = CreateConVar("sf2_issurvivalmap", "0", "Set to 1 if the map is a survival map.", _, true, 0.0, true, 1.0);
 	g_cvTimeEscapeSurvival = CreateConVar("sf2_survival_time_limit", "30", "when X secs left the mod will turn back the Survive! text to Escape! text", _, true, 0.0);
-
+	
 	g_cvMaxRounds = FindConVar("mp_maxrounds");
 	
 	g_hHudSync = CreateHudSynchronizer();

--- a/addons/sourcemod/scripting/sf2/functionclients/client_proxy_functions.sp
+++ b/addons/sourcemod/scripting/sf2/functionclients/client_proxy_functions.sp
@@ -1247,7 +1247,7 @@ public Action Timer_ClientPostWeapons(Handle timer, any userid)
 			int iItemDef = GetEntProp(iWeapon, Prop_Send, "m_iItemDefinitionIndex");
 			switch (iItemDef)
 			{
-				case 1101:
+				case 30, 212, 59, 60, 297, 947, 1101:	// Invis Watch, Base Jumper
 				{
 					TF2_RemoveWeaponSlotAndWearables(client, iSlot);
 				}

--- a/addons/sourcemod/scripting/sf2/functionclients/client_proxy_functions.sp
+++ b/addons/sourcemod/scripting/sf2/functionclients/client_proxy_functions.sp
@@ -799,7 +799,7 @@ public Action Timer_ClientPostWeapons(Handle timer, any userid)
 		bRemoveWeapons = false;
 		bRestrictWeapons = false;
 		bKeepUtilityItems = false;
-		bPreventAttack = false;
+		bPreventAttack = true;
 	}
 	
 	// pvp
@@ -1229,6 +1229,14 @@ public Action Timer_ClientPostWeapons(Handle timer, any userid)
 	if (bPreventAttack)
 	{
 		int iWeapon = INVALID_ENT_REFERENCE;
+		while ((iWeapon = FindEntityByClassname(iWeapon, "tf_wearable_demoshield")) != INVALID_ENT_REFERENCE)
+		{
+			if (GetEntPropEnt(iWeapon, Prop_Send, "m_hOwnerEntity") == client)
+			{
+				RemoveEntity(iWeapon);
+			}
+		}
+		
 		for (int iSlot = 0; iSlot <= 5; iSlot++)
 		{
 			if (iSlot == TFWeaponSlot_Melee) continue;
@@ -1236,8 +1244,19 @@ public Action Timer_ClientPostWeapons(Handle timer, any userid)
 			iWeapon = GetPlayerWeaponSlot(client, iSlot);
 			if (!iWeapon || iWeapon == INVALID_ENT_REFERENCE) continue;
 			
-			TF2Attrib_SetByDefIndex(iWeapon, 128, 1.0); // While active:
-			TF2Attrib_SetByDefIndex(iWeapon, 821, 1.0); // No Attack
+			int iItemDef = GetEntProp(iWeapon, Prop_Send, "m_iItemDefinitionIndex");
+			switch (iItemDef)
+			{
+				case 1101:
+				{
+					TF2_RemoveWeaponSlotAndWearables(client, iSlot);
+				}
+				default:
+				{
+					SetEntPropFloat(iWeapon, Prop_Send, "m_flNextPrimaryAttack", 99999999.9);
+					SetEntPropFloat(iWeapon, Prop_Send, "m_flNextSecondaryAttack", 99999999.9);
+				}
+			}
 		}
 	}
 	

--- a/addons/sourcemod/scripting/sf2/pvp.sp
+++ b/addons/sourcemod/scripting/sf2/pvp.sp
@@ -705,6 +705,8 @@ void PvP_SetPlayerPvPState(int iClient, bool bStatus, bool bRemoveProjectiles=tr
 	{
 		// Regenerate player but keep health the same.
 		int iHealth = GetEntProp(iClient, Prop_Send, "m_iHealth");
+		TF2_RemoveWeaponSlot(iClient, TFWeaponSlot_Primary);
+		TF2_RemoveWeaponSlot(iClient, TFWeaponSlot_Secondary);
 		TF2_RegeneratePlayer(iClient);
 		SetEntProp(iClient, Prop_Data, "m_iHealth", iHealth);
 		SetEntProp(iClient, Prop_Send, "m_iHealth", iHealth);


### PR DESCRIPTION
Adds a cvar `sf2_player_keep_weapons` to allow holding non-melee weapons while on BLU and outside PvP arenas.
Requested by @fearts 