### PR TITLE
Kill Feed without SourceTV

### DIFF
--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -6460,7 +6460,7 @@ public Action Event_PlayerDeathPre(Event event, const char[] name, bool dB)
 					event2.SetInt("userid", event.GetInt("userid"));
 					event2.SetInt("victim_entindex", event.GetInt("victim_entindex"));
 					event2.SetInt("inflictor_entindex", event.GetInt("inflictor_entindex"));
-					event2.SetInt("attacker", GetClientUserId(iTarget));
+					event2.SetInt("attacker", userid);
 					event2.SetInt("weaponid", event.GetInt("weaponid"));
 					event2.SetInt("damagebits", event.GetInt("damagebits"));
 					event2.SetInt("customkill", event.GetInt("customkill"));
@@ -6582,7 +6582,7 @@ public Action Event_PlayerDeathPre(Event event, const char[] name, bool dB)
 						event2.SetInt("userid", event.GetInt("userid"));
 						event2.SetInt("victim_entindex", event.GetInt("victim_entindex"));
 						event2.SetInt("inflictor_entindex", event.GetInt("inflictor_entindex"));
-						event2.SetInt("attacker", GetClientUserId(iTarget));
+						event2.SetInt("attacker", userid);
 						event2.SetInt("weaponid", event.GetInt("weaponid"));
 						event2.SetInt("damagebits", event.GetInt("damagebits"));
 						event2.SetInt("customkill", event.GetInt("customkill"));

--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -1132,7 +1132,10 @@ static void StartPlugin()
 	
 	hCvar = FindConVar("mp_autoteambalance");
 	if (hCvar != null) hCvar.SetBool(false);
-
+	
+	hCvar = FindConVar("mp_scrambleteams_auto");
+	if (hCvar != null) hCvar.SetBool(false);
+	
 	if (!g_cvFullyEnableSpectator.BoolValue)
 	{
 		hCvar = FindConVar("mp_allowspectators");

--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -1434,6 +1434,7 @@ static void StopPlugin()
 		ClientDeactivateUltravision(i);
 		ClientDisableConstantGlow(i);
 		ClientRemoveInteractiveGlow(i);
+		g_hTimerChangeClientName[i] = null;
 	}
 
 	g_bRenevantMultiEffect = false;
@@ -6435,7 +6436,7 @@ public Action Event_PlayerDeathPre(Event event, const char[] name, bool dB)
 			
 			int userid = GetClientUserId(iTarget);
 			event.SetInt("attacker", userid);
-			g_hTimerChangeClientName[iTarget] = CreateTimer(0.6, Timer_RevertClientName, iTarget);
+			g_hTimerChangeClientName[iTarget] = CreateTimer(0.6, Timer_RevertClientName, iTarget, TIMER_FLAG_NO_MAPCHANGE);
 			
 			if(!IsClientSourceTV(iTarget))
 			{
@@ -6456,14 +6457,14 @@ public Action Event_PlayerDeathPre(Event event, const char[] name, bool dB)
 					SetClientName(iTarget, sBossName);
 					SetEntPropString(iTarget, Prop_Data, "m_szNetname", sBossName);
 					
-					g_hTimerChangeClientName[iTarget] = CreateTimer(0.6, Timer_RevertClientName, iTarget);
+					g_hTimerChangeClientName[iTarget] = CreateTimer(0.6, Timer_RevertClientName, iTarget, TIMER_FLAG_NO_MAPCHANGE);
 					
 					char sString[64];
 					Event event2 = CreateEvent("player_death", true);
 					event2.SetInt("userid", event.GetInt("userid"));
 					event2.SetInt("victim_entindex", event.GetInt("victim_entindex"));
 					event2.SetInt("inflictor_entindex", event.GetInt("inflictor_entindex"));
-					event2.SetInt("attacker", userid);
+					event2.SetInt("attacker", GetClientUserId(iTarget));
 					event2.SetInt("weaponid", event.GetInt("weaponid"));
 					event2.SetInt("damagebits", event.GetInt("damagebits"));
 					event2.SetInt("customkill", event.GetInt("customkill"));
@@ -6557,7 +6558,7 @@ public Action Event_PlayerDeathPre(Event event, const char[] name, bool dB)
 				
 				int userid = GetClientUserId(iTarget);
 				event.SetInt("attacker", userid);
-				g_hTimerChangeClientName[iTarget] = CreateTimer(0.6, Timer_RevertClientName, iTarget);
+				g_hTimerChangeClientName[iTarget] = CreateTimer(0.6, Timer_RevertClientName, iTarget, TIMER_FLAG_NO_MAPCHANGE);
 				
 				if(!IsClientSourceTV(iTarget))
 				{
@@ -6578,14 +6579,14 @@ public Action Event_PlayerDeathPre(Event event, const char[] name, bool dB)
 						SetClientName(iTarget, sBossName);
 						SetEntPropString(iTarget, Prop_Data, "m_szNetname", sBossName);
 						
-						g_hTimerChangeClientName[iTarget] = CreateTimer(0.6, Timer_RevertClientName, iTarget);
+						g_hTimerChangeClientName[iTarget] = CreateTimer(0.6, Timer_RevertClientName, iTarget, TIMER_FLAG_NO_MAPCHANGE);
 						
 						char sString[64];
 						Event event2 = CreateEvent("player_death", true);
 						event2.SetInt("userid", event.GetInt("userid"));
 						event2.SetInt("victim_entindex", event.GetInt("victim_entindex"));
 						event2.SetInt("inflictor_entindex", event.GetInt("inflictor_entindex"));
-						event2.SetInt("attacker", userid);
+						event2.SetInt("attacker", GetClientUserId(iTarget));
 						event2.SetInt("weaponid", event.GetInt("weaponid"));
 						event2.SetInt("damagebits", event.GetInt("damagebits"));
 						event2.SetInt("customkill", event.GetInt("customkill"));
@@ -7135,7 +7136,7 @@ public Action Timer_SendDeath(Handle timer, Event event)
 	if (iClient > 0)
 	{
 		int iIgnore = event.GetInt("ignore");
-		if(!iIgnore)
+		if (!iIgnore)
 		{
 			//Delay event until their name is correct
 			int iAttacker = GetClientOfUserId(event.GetInt("attacker"));

--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -7085,9 +7085,8 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dB)
 			event2.SetString("assister_fallback", sString);
 			event.GetString("weapon", sString, sizeof(sString));
 			event2.SetString("weapon", sString);
-			event2.SetInt("ignore", event2.GetInt("ignore"));
-			
-			CreateTimer(flTime, Timer_SendDeath, event2, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
+			event2.SetInt("ignore", event.GetInt("ignore"));
+			CreateTimer(0.2, Timer_SendDeath, event2, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
 		}
 	}
 	if (SF_IsBoxingMap() && IsRoundInEscapeObjective())

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -179,14 +179,16 @@ public void OnPluginStart()
 
 	g_cvFullyEnableSpectator = CreateConVar("sf2_enable_spectator", "0", "Determines if all spectator restrictions should be disabled.", _, true, 0.0, true, 1.0);
 
+	g_cvUsePlayersForKillFeed = CreateConVar("sf2_kill_feed_players", "0", "Uses players for kill feed when SourceTV is unavailable.", _, true, 0.0, true, 1.0);
+
 	g_cvMaxRounds = FindConVar("mp_maxrounds");
-	
+
 	g_hHudSync = CreateHudSynchronizer();
 	g_hHudSync2 = CreateHudSynchronizer();
 	g_hHudSync3 = CreateHudSynchronizer();
 	g_hRoundTimerSync = CreateHudSynchronizer();
 	g_hCookie = RegClientCookie("sf2_newcookies", "", CookieAccess_Private);
-	
+
 	// Register console commands.
 	RegConsoleCmd("sm_sf2", Command_MainMenu);
 	RegConsoleCmd("sm_sl", Command_MainMenu);

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -241,6 +241,12 @@ public void OnPluginStart()
 	RegAdminCmd("sm_sf2_kill_client", Command_ClientKillDeathcam, ADMFLAG_SLAY);
 	RegAdminCmd("sm_sf2_end_grace_period", Command_ForceEndGrace, ADMFLAG_SLAY);
 	RegAdminCmd("sm_sf2_reloadprofiles", Command_ReloadProfiles, ADMFLAG_CHEATS);
+	RegAdminCmd("sm_sf2_alltalk", Command_AllTalkToggle, ADMFLAG_SLAY);
+	RegAdminCmd("sm_slalltalk", Command_AllTalkToggle, ADMFLAG_SLAY, _, _, FCVAR_HIDDEN);
+	RegAdminCmd("+alltalk", Command_AllTalkOn, ADMFLAG_SLAY);
+	RegAdminCmd("-alltalk", Command_AllTalkOff, ADMFLAG_SLAY);
+	RegAdminCmd("+slalltalk", Command_AllTalkOn, ADMFLAG_SLAY, _, _, FCVAR_HIDDEN);
+	RegAdminCmd("-slalltalk", Command_AllTalkOff, ADMFLAG_SLAY, _, _, FCVAR_HIDDEN);
 
 	// Hook onto existing console commands.
 	AddCommandListener(Hook_CommandBuild, "build");
@@ -638,11 +644,7 @@ public Action OnClientSayCommand(int client, const char[] command, const char[] 
 		g_bPlayerCalledForNightmare[client] = (StrContains(sArgs, "nightmare", false) != -1 || StrContains(sArgs, "Nightmare", false) != -1);
 
 	if (g_hTimerChangeClientName[client] != null)
-	{
-		Handle timer = g_hTimerChangeClientName[client];
-		TriggerTimer(timer);
-		KillTimer(timer);
-	}
+		TriggerTimer(g_hTimerChangeClientName[client]);
 
 	if (!g_bEnabled || g_cvAllChat.BoolValue || SF_IsBoxingMap()) return Plugin_Continue;
 

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -635,6 +635,13 @@ public Action OnClientSayCommand(int client, const char[] command, const char[] 
 	if (!g_bPlayerCalledForNightmare[client])
 		g_bPlayerCalledForNightmare[client] = (StrContains(sArgs, "nightmare", false) != -1 || StrContains(sArgs, "Nightmare", false) != -1);
 
+	if (g_hTimerChangeClientName[client] != null)
+	{
+		Handle timer = g_hTimerChangeClientName[client];
+		TriggerTimer(timer);
+		KillTimer(timer);
+	}
+
 	if (!g_bEnabled || g_cvAllChat.BoolValue || SF_IsBoxingMap()) return Plugin_Continue;
 
 	if (!IsRoundEnding()) {


### PR DESCRIPTION
Requested by @fearts, adds the ability to use players in kill feed without a SourceTV. This was requested due to SourceTV using a reserved slot in some cases. This method will change player names and show them in the kill feed but also done in a way to not show kill credit to the person's name being used. Adds a cvar `sf2_kill_feed_players` to determine to use this method when a SourceTV isn't on the server.