### PR TITLE
Thirdperson Peeking

### DIFF
--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -1850,6 +1850,7 @@ public Action Hook_CommandTaunt(int iClient, const char[] command, int argc)
 {
 	if (!g_bEnabled) return Plugin_Continue;
 	if (!g_bPlayerEliminated[iClient] && GetRoundState() == SF2RoundState_Intro) return Plugin_Handled;
+	if (!g_bPlayerEliminated[iClient] && ClientStartPeeking(iClient)) return Plugin_Handled;
 	if (IsClientInGhostMode(iClient)) return Plugin_Handled;
 	
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -873,6 +873,7 @@ ConVar g_cvSlaughterRunDivisibleTime;
 ConVar g_cvUseAlternateConfigDirectory;
 ConVar g_cvPlayerKeepWeapons;
 ConVar g_cvFullyEnableSpectator;
+ConVar g_cvAllowPlayerPeeking;
 
 ConVar g_cvRestartSession;
 bool g_bRestartSessionEnabled;
@@ -2570,6 +2571,7 @@ public Action Hook_NormalSound(int clients[64], int &numClients, char sample[PLA
 				case SNDCHAN_VOICE:
 				{
 					if (IsRoundInIntro()) return Plugin_Handled;
+					if (!StrContains(sample, "vo/halloween_scream")) return Plugin_Handled;
 					
 					for (int iBossIndex = 0; iBossIndex < MAX_BOSSES; iBossIndex++)
 					{

--- a/addons/sourcemod/scripting/sf2/client.sp
+++ b/addons/sourcemod/scripting/sf2/client.sp
@@ -107,6 +107,9 @@ char g_sClientProxyModelApollyon[MAXPLAYERS + 1][PLATFORM_MAX_PATH];
 //static CNavArea g_lastNavArea[MAXPLAYERS + 1];
 static float g_flClientAllowedTimeNearEscape[MAXPLAYERS + 1];
 
+//Peeking Data
+static bool g_bPlayerPeeking[MAXPLAYERS + 1] = { false, ... };
+
 //	==========================================================
 //	GENERAL CLIENT HOOK FUNCTIONS
 //	==========================================================
@@ -1905,6 +1908,28 @@ void ClientHandleSprint(int client, bool bSprint)
 		{
 			ClientStopSprint(client);
 		}
+	}
+}
+ /**
+  *	Handles thirdperson peeking
+  */
+bool ClientStartPeeking(int client)
+{
+	if (!g_bPlayerPeeking[client] && g_cvAllowPlayerPeeking.BoolValue && !TF2_IsPlayerInCondition(client, TFCond_Dazed) && GetClientButtons(client) & IN_DUCK)
+	{
+		TF2_StunPlayer(client, 999.9, 1.0, TF_STUNFLAGS_LOSERSTATE);
+		g_bPlayerPeeking[client] = true;
+		return true;
+	}
+	return false;
+}
+
+void ClientEndPeeking(int client)
+{
+	if (g_bPlayerPeeking[client])
+	{
+		TF2_RemoveCondition(client, TFCond_Dazed);
+		g_bPlayerPeeking[client] = false;
 	}
 }
 

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -179,6 +179,8 @@ public void OnPluginStart()
 
 	g_cvFullyEnableSpectator = CreateConVar("sf2_enable_spectator", "0", "Determines if all spectator restrictions should be disabled.", _, true, 0.0, true, 1.0);
 
+	g_cvAllowPlayerPeeking = CreateConVar("sf2_player_peeking", "0", "Allow players to go into thirdperson by crouching and taunting.", _, true, 0.0, true, 1.0);
+
 	g_cvMaxRounds = FindConVar("mp_maxrounds");
 	
 	g_hHudSync = CreateHudSynchronizer();

--- a/addons/sourcemod/scripting/sf2/functionclients/clients_think.sp
+++ b/addons/sourcemod/scripting/sf2/functionclients/clients_think.sp
@@ -1062,6 +1062,8 @@ void ClientOnButtonRelease(int client,int button)
 		}
 		case IN_DUCK:
 		{
+			ClientEndPeeking(client);
+			
 			if (IsClientInGhostMode(client))
 			{
 				SetEntityGravity(client, 0.5);

--- a/addons/sourcemod/scripting/sf2/pvp.sp
+++ b/addons/sourcemod/scripting/sf2/pvp.sp
@@ -634,7 +634,7 @@ public Action PvP_OnTriggerEndTouch(int trigger,int iOther)
 	}
 
 	//A projectile went off pvp area. (Experimental)
-	if (iOther>MaxClients && IsValidEntity(iOther) && !GetEntProp(iOther, Prop_Send, "m_iDeflected"))
+	if (iOther>MaxClients && IsValidEntity(iOther))
 	{
 		//Get entity's classname.
 		char sClassname[50];
@@ -643,9 +643,12 @@ public Action PvP_OnTriggerEndTouch(int trigger,int iOther)
 		{
 			if (strcmp(sClassname, g_sPvPProjectileClasses[i], false) == 0)
 			{
-				//Yup it's a projectile zap it!
-				//But we have to wait to prevent some bugs.
-				CreateTimer(0.1,EntityStillAlive,iOther,TIMER_FLAG_NO_MAPCHANGE);
+				if (!GetEntProp(iOther, Prop_Send, "m_iDeflected"))
+				{
+					//Yup it's a projectile zap it!
+					//But we have to wait to prevent some bugs.
+					CreateTimer(0.1,EntityStillAlive,iOther,TIMER_FLAG_NO_MAPCHANGE);
+				}
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/sf2/pvp.sp
+++ b/addons/sourcemod/scripting/sf2/pvp.sp
@@ -634,7 +634,7 @@ public Action PvP_OnTriggerEndTouch(int trigger,int iOther)
 	}
 
 	//A projectile went off pvp area. (Experimental)
-	if (iOther>MaxClients && IsValidEntity(iOther))
+	if (iOther>MaxClients && IsValidEntity(iOther) && !GetEntProp(iOther, Prop_Send, "m_iDeflected"))
 	{
 		//Get entity's classname.
 		char sClassname[50];


### PR DESCRIPTION
Requested by @fearts, adds a new mechanic to allow players to toggle thirdperson while standing still. Players must taunt and hold crouch to activate and let go of crouch to move again. This was done due to corner peeking being changed in recent updates and to help cases in taunting being P2W with some available taunts. Controlled by `sf2_player_peeking` cvar.