### PR TITLE
Make Grace period its own round state

### DIFF
--- a/addons/sourcemod/scripting/include/sf2.inc
+++ b/addons/sourcemod/scripting/include/sf2.inc
@@ -134,6 +134,7 @@ enum SF2RoundState
 	SF2RoundState_Invalid = -1,
 	SF2RoundState_Waiting = 0,		// waiting for players
 	SF2RoundState_Intro,				// if intro is enabled, intro stage for RED
+	SF2RoundState_Grace,			// round is in grace period for RED
 	SF2RoundState_Active,			// round is running for RED
 	SF2RoundState_Escape,			// escape stage for RED
 	SF2RoundState_Outro				// round win for a team, next round coming soon

--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -3971,6 +3971,45 @@ void SetRoundState(SF2RoundState iRoundState)
 				}
 			}
 
+			if (g_bRestartSessionEnabled)
+			{
+				ArrayList hSpawnPoint = new ArrayList();
+#if defined DEBUG
+				SendDebugMessageToPlayers(DEBUG_ARRAYLIST, 0, "Array list %b has been created for hSpawnPoint in SetRoundState(SF2RoundState_Grace).", hSpawnPoint);
+#endif
+				float flTeleportPos[3];
+				int ent = -1, iSpawnTeam = 0;
+				while ((ent = FindEntityByClassname(ent, "info_player_teamspawn")) != -1)
+				{
+					iSpawnTeam = GetEntProp(ent, Prop_Data, "m_iInitialTeamNum");
+					if (iSpawnTeam == TFTeam_Red)
+					{
+						hSpawnPoint.Push(ent);
+					}
+					
+				}
+				ent = -1;
+				if (hSpawnPoint.Length > 0)
+				{
+					for (int iNPCIndex = 0; iNPCIndex < MAX_BOSSES; iNPCIndex++)
+					{
+						ent = hSpawnPoint.Get(GetRandomInt(0, hSpawnPoint.Length - 1));
+						
+						if (IsValidEntity(ent))
+						{
+							GetEntPropVector(ent, Prop_Data, "m_vecAbsOrigin", flTeleportPos);
+							SF2NPC_BaseNPC Npc = view_as<SF2NPC_BaseNPC>(iNPCIndex);
+							if (!Npc.IsValid()) continue;
+							SpawnSlender(Npc, flTeleportPos);
+						}
+					}
+				}
+				delete hSpawnPoint;
+#if defined DEBUG
+				SendDebugMessageToPlayers(DEBUG_ARRAYLIST, 0, "Array list %b has been deleted for hSpawnPoint in SetRoundState(SF2RoundState_Grace).", hSpawnPoint);
+#endif
+			}
+
 			CPrintToChatAll("{dodgerblue}%t", "SF2 Grace Period End");
 		}
 		case SF2RoundState_Active:
@@ -7879,45 +7918,6 @@ public Action Timer_CheckRoundWinConditions(Handle timer)
 public Action Timer_RoundGrace(Handle timer)
 {
 	if (timer != g_hRoundGraceTimer) return Plugin_Stop;
-
-	if (g_bRestartSessionEnabled)
-	{
-		ArrayList hSpawnPoint = new ArrayList();
-		#if defined DEBUG
-		SendDebugMessageToPlayers(DEBUG_ARRAYLIST, 0, "Array list %b has been created for hSpawnPoint in Timer_RoundGrace.", hSpawnPoint);
-		#endif
-		float flTeleportPos[3];
-		int ent = -1, iSpawnTeam = 0;
-		while ((ent = FindEntityByClassname(ent, "info_player_teamspawn")) != -1)
-		{
-			iSpawnTeam = GetEntProp(ent, Prop_Data, "m_iInitialTeamNum");
-			if (iSpawnTeam == TFTeam_Red)
-			{
-				hSpawnPoint.Push(ent);
-			}
-			
-		}
-		ent = -1;
-		if (hSpawnPoint.Length > 0)
-		{
-			for (int iNPCIndex = 0; iNPCIndex < MAX_BOSSES; iNPCIndex++)
-			{
-				ent = hSpawnPoint.Get(GetRandomInt(0, hSpawnPoint.Length - 1));
-				
-				if (IsValidEntity(ent))
-				{
-					GetEntPropVector(ent, Prop_Data, "m_vecAbsOrigin", flTeleportPos);
-					SF2NPC_BaseNPC Npc = view_as<SF2NPC_BaseNPC>(iNPCIndex);
-					if (!Npc.IsValid()) continue;
-					SpawnSlender(Npc, flTeleportPos);
-				}
-			}
-		}
-		delete hSpawnPoint;
-		#if defined DEBUG
-		SendDebugMessageToPlayers(DEBUG_ARRAYLIST, 0, "Array list %b has been deleted for hSpawnPoint in Timer_RoundGrace.", hSpawnPoint);
-		#endif
-	}
 	
 	SetRoundState(SF2RoundState_Active);
 	return Plugin_Stop;
@@ -9246,7 +9246,7 @@ void InitializeNewGame()
 	}
 	else
 	{
-		SetRoundState(SF2RoundState_Active);
+		SetRoundState(SF2RoundState_Grace);
 		SF2_RefreshRestrictions();
 	}
 	
@@ -9580,7 +9580,7 @@ public Action Timer_ActivateRoundFromIntro(Handle timer)
 	if (g_hRoundIntroTimer != timer) return Plugin_Stop;
 	
 	// Obviously we don't want to spawn the boss when g_strRoundBossProfile isn't set yet.
-	SetRoundState(SF2RoundState_Active);
+	SetRoundState(SF2RoundState_Grace);
 	SF2_RefreshRestrictions();
 	
 	// Spawn the boss!

--- a/addons/sourcemod/scripting/sf2/client.sp
+++ b/addons/sourcemod/scripting/sf2/client.sp
@@ -3522,7 +3522,7 @@ public Action Timer_RespawnPlayer(Handle timer, any userid)
 	
 	if (!IsValidClient(client) || !IsClientInGame(client) || IsPlayerAlive(client)) return Plugin_Stop;
 
-	if (SF_SpecialRound(SPECIALROUND_1UP) && g_bPlayerIn1UpCondition[client] && !DidClientEscape(client) && !IsRoundEnding() && !IsRoundInWarmup() && !IsRoundInIntro() && !g_bRoundGrace) 
+	if (SF_SpecialRound(SPECIALROUND_1UP) && g_bPlayerIn1UpCondition[client] && !DidClientEscape(client) && !IsRoundEnding() && !IsRoundInWarmup() && !IsRoundInIntro() && IsRoundPlaying()) 
 	{
 		g_bPlayerDied1Up[client] = true;
 		g_bPlayerIn1UpCondition[client] = false;

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -688,7 +688,7 @@ public Action Hook_CommandSuicideAttempt(int iClient, const char[] command,int a
 	
 	if (g_cvBlockSuicideDuringRound.BoolValue)
 	{
-		if (!g_bRoundGrace && !g_bPlayerEliminated[iClient] && !DidClientEscape(iClient))
+		if (IsRoundPlaying() && !g_bPlayerEliminated[iClient] && !DidClientEscape(iClient))
 		{
 			return Plugin_Handled;
 		}
@@ -716,7 +716,7 @@ public Action Hook_CommandPreventJoinTeam(int iClient, const char[] command,int 
 	
 	if (g_cvBlockSuicideDuringRound.BoolValue)
 	{
-		if (!g_bRoundGrace && !g_bPlayerEliminated[iClient] && !DidClientEscape(iClient))
+		if (IsRoundPlaying() && !g_bPlayerEliminated[iClient] && !DidClientEscape(iClient))
 		{
 			return Plugin_Handled;
 		}
@@ -744,7 +744,7 @@ public Action Hook_BlockCommand(int iClient, const char[] command,int argc)
 public Action Hook_BlockLoadout(int iClient, const char[] command,int argc) 
 {
 	if (!g_bEnabled) return Plugin_Continue;
-	if (!g_bRoundGrace && !g_bPlayerEliminated[iClient] && !DidClientEscape(iClient)) return Plugin_Handled;
+	if (IsRoundPlaying() && !g_bPlayerEliminated[iClient] && !DidClientEscape(iClient)) return Plugin_Handled;
 	return Plugin_Continue;
 }
 

--- a/addons/sourcemod/scripting/sf2/extras/natives.sp
+++ b/addons/sourcemod/scripting/sf2/extras/natives.sp
@@ -405,7 +405,7 @@ public int Native_GetRoundState(Handle plugin,int numParams)
 
 public int Native_IsRoundInGracePeriod(Handle plugin, int numParams)
 {
-	return g_bRoundGrace;
+	return GetRoundState() == SF2RoundState_Grace;
 }
 
 public int Native_GetCurrentDifficulty(Handle plugin,int numParams)

--- a/addons/sourcemod/scripting/sf2/functionclients/clients_think.sp
+++ b/addons/sourcemod/scripting/sf2/functionclients/clients_think.sp
@@ -1223,7 +1223,7 @@ public Action Timer_ClientCheckCamp(Handle timer, any userid)
 		/*if(IsSpaceOccupiedIgnorePlayers(flPos, flMins, flMaxs, client))
 			//LogSF2Message("[SF2 AFK TIMER] Client %i (%N) is stuck, no actions taken", client, client);*/
 		if (!SF_IsBoxingMap() && g_cvCampingEnabled.BoolValue && 
-			!g_bRoundGrace &&
+			IsRoundPlaying() &&
 			g_flPlayerStaticAmount[client] <= g_cvCampingNoStrikeSanity.FloatValue && 
 			(iClosestBoss == -1 || flDistFromClosestBoss >= g_cvCampingNoStrikeBossDistance.FloatValue) &&
 			flDistFromLastPosition <= SquareFloat(g_cvCampingMinDistance.FloatValue))

--- a/addons/sourcemod/scripting/sf2/mapentities.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities.sp
@@ -7,7 +7,6 @@
 
 static PrivateForward g_CustomEntityOnMapStart;
 static PrivateForward g_CustomEntityOnRoundStateChanged;
-static PrivateForward g_CustomEntityOnGracePeriodEnd;
 static PrivateForward g_CustomEntityOnDifficultyChanged;
 static PrivateForward g_CustomEntityOnPageCountChanged;
 
@@ -47,7 +46,6 @@ enum SF2MapEntityHook
 {
 	SF2MapEntityHook_OnMapStart,
 	SF2MapEntityHook_OnRoundStateChanged,
-	SF2MapEntityHook_OnGracePeriodEnd,
 	SF2MapEntityHook_OnDifficultyChanged,
 	SF2MapEntityHook_OnPageCountChanged,
 	SF2MapEntityHook_OnRenevantWaveTriggered,
@@ -62,8 +60,6 @@ void SF2MapEntity_AddHook(SF2MapEntityHook hookType, Function hookFunc)
 			g_CustomEntityOnMapStart.AddFunction(null, hookFunc);
 		case SF2MapEntityHook_OnRoundStateChanged:
 			g_CustomEntityOnRoundStateChanged.AddFunction(null, hookFunc);
-		case SF2MapEntityHook_OnGracePeriodEnd:
-			g_CustomEntityOnGracePeriodEnd.AddFunction(null, hookFunc);
 		case SF2MapEntityHook_OnDifficultyChanged:
 			g_CustomEntityOnDifficultyChanged.AddFunction(null, hookFunc);
 		case SF2MapEntityHook_OnPageCountChanged:
@@ -102,7 +98,6 @@ void SetupCustomMapEntities()
 {
 	g_CustomEntityOnMapStart = new PrivateForward(ET_Ignore);
 	g_CustomEntityOnRoundStateChanged = new PrivateForward(ET_Ignore, Param_Cell, Param_Cell);
-	g_CustomEntityOnGracePeriodEnd = new PrivateForward(ET_Ignore);
 	g_CustomEntityOnDifficultyChanged = new PrivateForward(ET_Ignore, Param_Cell, Param_Cell);
 	g_CustomEntityOnPageCountChanged = new PrivateForward(ET_Ignore, Param_Cell, Param_Cell);
 
@@ -268,12 +263,6 @@ void SF2MapEntity_OnPageCountChanged(int iPageCount, int iOldPageCount)
 	Call_StartForward(g_CustomEntityOnPageCountChanged);
 	Call_PushCell(iPageCount);
 	Call_PushCell(iOldPageCount);
-	Call_Finish();
-}
-
-void SF2MapEntity_OnGracePeriodEnd()
-{
-	Call_StartForward(g_CustomEntityOnGracePeriodEnd);
 	Call_Finish();
 }
 

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_gamerules.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_gamerules.sp
@@ -307,6 +307,8 @@ static void Initialize()
 		.DefineOutput("OnStateExitWaiting")
 		.DefineOutput("OnStateEnterIntro")
 		.DefineOutput("OnStateExitIntro")
+		.DefineOutput("OnStateEnterGrace")
+		.DefineOutput("OnStateExitGrace")
 		.DefineOutput("OnStateEnterActive")
 		.DefineOutput("OnStateExitActive")
 		.DefineOutput("OnStateEnterEscape")
@@ -338,7 +340,6 @@ static void Initialize()
 
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnRoundStateChanged, OnRoundStateChanged);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnPageCountChanged, OnPageCountChanged);
-	SF2MapEntity_AddHook(SF2MapEntityHook_OnGracePeriodEnd, OnGracePeriodEnd);
 	SF2MapEntity_AddHook(SF2MapEntityHook_OnDifficultyChanged, OnDifficultyChanged);
 }
 
@@ -422,6 +423,11 @@ static void OnRoundStateChanged(SF2RoundState iRoundState, SF2RoundState iOldRou
 			gameRules.FireOutput("OnStateExitWaiting");
 		case SF2RoundState_Intro:
 			gameRules.FireOutput("OnStateExitIntro");
+		case SF2RoundState_Grace:
+		{
+			gameRules.FireOutput("OnGracePeriodEnded");
+			gameRules.FireOutput("OnStateExitGrace");
+		}
 		case SF2RoundState_Active:
 			gameRules.FireOutput("OnStateExitActive");
 		case SF2RoundState_Escape:
@@ -436,6 +442,8 @@ static void OnRoundStateChanged(SF2RoundState iRoundState, SF2RoundState iOldRou
 			gameRules.FireOutput("OnStateEnterWaiting");
 		case SF2RoundState_Intro:
 			gameRules.FireOutput("OnStateEnterIntro");
+		case SF2RoundState_Grace:
+			gameRules.FireOutput("OnStateEnterGrace");
 		case SF2RoundState_Active:
 			gameRules.FireOutput("OnStateEnterActive");
 		case SF2RoundState_Escape:
@@ -463,15 +471,6 @@ static void OnPageCountChanged(int iPageCount, int iOldPageCount)
 
 	if (sOutputName[0] != '\0')
 		gameRules.FireOutput(sOutputName);
-}
-
-static void OnGracePeriodEnd()
-{
-	SF2GamerulesEntity gameRules = FindSF2GamerulesEntity();
-	if (!gameRules.IsValid())
-		return;
-
-	gameRules.FireOutput("OnGracePeriodEnded");
 }
 
 static void OnDifficultyChanged(int iDifficulty, int iOldDifficulty)
@@ -636,6 +635,6 @@ static void InputSetDifficulty(int entity, int activator, int caller, int value)
 
 static void InputEndGracePeriod(int entity, int activator, int caller)
 {
-	if (g_bRoundGrace && g_hRoundGraceTimer != INVALID_HANDLE) 
+	if (GetRoundState() == SF2RoundState_Grace && g_hRoundGraceTimer != null) 
 		TriggerTimer(g_hRoundGraceTimer);
 }

--- a/addons/sourcemod/scripting/sf2/npc.sp
+++ b/addons/sourcemod/scripting/sf2/npc.sp
@@ -2653,7 +2653,7 @@ void RemoveProfile(int iBossIndex)
 
 void SpawnSlender(SF2NPC_BaseNPC Npc, const float pos[3])
 {
-	if (g_bRoundGrace) return;
+	if (!IsRoundPlaying()) return;
 
 	if (SF_IsRenevantMap() && GetRoundState() != SF2RoundState_Escape) return; // Stop spawning bosses before all pages are picked up in Renevant.
 
@@ -4169,7 +4169,7 @@ public Action Timer_SlenderTeleportThink(Handle timer, any iBossIndex)
 	char sProfile[SF2_MAX_PROFILE_NAME_LENGTH];
 	NPCGetProfile(iBossIndex, sProfile, sizeof(sProfile));
 	
-	if (!g_bRoundGrace)
+	if (IsRoundPlaying())
 	{
 		if (GetGameTime() >= g_flSlenderNextTeleportTime[iBossIndex])
 		{
@@ -4942,7 +4942,7 @@ bool SpawnProxy(int client, int iBossIndex, float flTeleportPos[3], int &iSpawnP
 	if (iBossIndex == -1 || client <= 0) 
 		return false;
 
-	if (g_bRoundGrace)
+	if (!IsRoundPlaying())
 		return false;
 	
 	if (!(NPCGetFlags(iBossIndex) & SFF_PROXIES)) return false;

--- a/sf2.fgd
+++ b/sf2.fgd
@@ -17,6 +17,8 @@
 
 	initialtimelimit(integer) : "Time Limit (in seconds)" : 200 : "How much time the players start out with after exiting grace period. This is set at round start."
 
+	pagemusicupdateloop(float) : "Page Music Update Loop (in seconds)" : "0.0" : "(Private only) If non-zero, then this makes the page music update at a fixed interval instead of every time a page is collected. This can provide a nice, transitive effect if your page music tracks play at the same BPM and if you want the page music to transition only at the beats of the music."
+
 	pagecollectaddtime(integer) : "Time to Add on Page Collect (in seconds)" : 30 : "How much time to add to the clock upon collecting a page. This is set at round start."
 
 	pagecollectsound(sound) : "Page Collect Sound" : "slender/slenderpagegrab.wav" : "The sound path of the sound played when collecting a page. This is set at round start."
@@ -135,6 +137,8 @@
 	output OnStateExitWaiting(void) : "Sent when exiting the Waiting round state."
 	output OnStateEnterIntro(void) : "Sent when entering the Intro round state."
 	output OnStateExitIntro(void) : "Sent when exiting the Intro round state."
+	output OnStateEnterGrace(void) : "Sent when entering the Grace round state."
+	output OnStateExitGrace(void) : "Sent when exiting the Grace round state."
 	output OnStateEnterActive(void) : "Sent when entering the Active round state."
 	output OnStateExitActive(void) : "Sent when exiting the Active round state."
 	output OnStateEnterEscape(void) : "Sent when entering the Escape round state."


### PR DESCRIPTION
This converts the grace period into a defined round state. The code in SF2 treats grace period as its own separate state, so it should be converted to be so. The outputs `OnStateEnterGrace` and `OnStateExitGrace` are added to `sf2_gamerules` to make it consistent with the other outputs on the entity. `OnGracePeriodEnded` will stay for backwards compatibility.

The only thing to take note of here is that this adds the `SF2RoundState_Grace` value to the `SF2RoundState` enum. This will cause a shift, so any external plugins that depend on the enum needs to be recompiled. I considered adding it to the end instead, but instead kept it in the order that a round typically goes through states for consistency.

The .fgd has also been updated to Private's latest version.
