### PR TITLE
sf2_ignore_round_win_conditions Toggle Command

### DIFF
--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -1866,5 +1866,6 @@ public Action Command_AllTalkOff(int iClient, int args)
 public Action Command_ConditionToggle(int iClient, int args)
 {
 	g_cvIgnoreRoundWinConditions.BoolValue = !g_cvIgnoreRoundWinConditions.BoolValue;
+	CPrintToChat(iClient, "{royalblue}%t{default}Round condition is now %sabled.", "SF2 Prefix", g_cvIgnoreRoundWinConditions.BoolValue ? "dis" : "en");
 	return Plugin_Handled;
 }

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -265,6 +265,8 @@ public void OnPluginStart()
 	RegAdminCmd("sm_sf2_reloadprofiles", Command_ReloadProfiles, ADMFLAG_CHEATS);
 	RegAdminCmd("sm_sf2_alltalk", Command_AllTalkToggle, ADMFLAG_SLAY);
 	RegAdminCmd("sm_slalltalk", Command_AllTalkToggle, ADMFLAG_SLAY, _, _, FCVAR_HIDDEN);
+	RegAdminCmd("sm_sf2_eventmode", Command_ConditionToggle, ADMFLAG_CONVARS);
+	RegAdminCmd("sm_sleventmode", Command_ConditionToggle, ADMFLAG_CONVARS, _, _, FCVAR_HIDDEN);
 	RegAdminCmd("+alltalk", Command_AllTalkOn, ADMFLAG_SLAY);
 	RegAdminCmd("-alltalk", Command_AllTalkOff, ADMFLAG_SLAY);
 	RegAdminCmd("+slalltalk", Command_AllTalkOn, ADMFLAG_SLAY, _, _, FCVAR_HIDDEN);
@@ -1860,3 +1862,9 @@ public Action Command_AllTalkOff(int iClient, int args)
 	}
 	return Plugin_Handled;
 } 
+
+public Action Command_ConditionToggle(int iClient, int args)
+{
+	g_cvIgnoreRoundWinConditions.BoolValue = !g_cvIgnoreRoundWinConditions.BoolValue;
+	return Plugin_Handled;
+}


### PR DESCRIPTION
Requested by @fearts, adds a command sm_sf2_eventmode that toggles  sf2_ignore_round_win_conditions convar.