### PR TITLE
Fix Sniper Rifles in PvP

### DIFF
--- a/addons/sourcemod/scripting/sf2/pvp.sp
+++ b/addons/sourcemod/scripting/sf2/pvp.sp
@@ -1007,15 +1007,7 @@ MRESReturn PvP_GetWeaponCustomDamageType(int weapon, int client, int &customDama
 
 				return MRES_Supercede;
 			}
-			else
-			{
-				return MRES_Ignored;
-			}
 		}
-	}
-	else
-	{
-		return MRES_Ignored;
 	}
 
 	return MRES_Ignored;


### PR DESCRIPTION
Where it won't check other classnames other then tf_weapon_sniperrifle