### PR TITLE
No Spectators in Kill Feed

### DIFF
--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -6757,7 +6757,7 @@ static int GetClientForDeath(int exclude1, int exclude2 = 0)
 		// Use AFKs first
 		for (int i = 1; i <= MaxClients; i++)
 		{
-			if (i != exclude1 && i != exclude2 && IsClientInGame(i) && g_bPlayerNoPoints[i])
+			if (i != exclude1 && i != exclude2 && IsClientInGame(i) && GetClientTeam(i) > TFTeam_Spectator && g_bPlayerNoPoints[i])
 				return i;
 		}
 


### PR DESCRIPTION
Requested by @fearts, prevents spectators from being used in the kill feed while `sf2_kill_feed_players` is enabled.