### PR TITLE
Add "teleport_allowed" keyvalue

### DIFF
--- a/addons/sourcemod/configs/sf2/profiles_documentation.cfg
+++ b/addons/sourcemod/configs/sf2/profiles_documentation.cfg
@@ -289,6 +289,7 @@
 // =============================================================
 //
 // "teleport_type" - Determines teleportation behavior. Only values 0 and 2 are accepted. 0 = teleport only when no player is looking at the boss. 2 = teleport only when no player is looking at the boss AND is behind an obstruction, blocking all possible view
+// "teleport_allowed" - Boolean (0/1) that determines if the boss is allowed to teleport. Default is "1". Difficulty key values are supported.
 // "teleport_range_min" - Determines how close the boss can teleport to a player (or any player for that matter), in relation to the NavMesh.. Difficulty key values are supported.
 // "teleport_range_max" - The maximum distance the boss can teleport away from a player, in relation to the NavMesh.. Difficulty key values are supported.
 // "teleport_target_rest_period" - Determines how long a boss should leave its previous teleportation target alone. Default is "15.0". Difficulty key values are supported.

--- a/addons/sourcemod/scripting/sf2/npc.sp
+++ b/addons/sourcemod/scripting/sf2/npc.sp
@@ -50,6 +50,7 @@ static float g_flNPCFieldOfView[MAX_BOSSES] = { 0.0, ... };
 static float g_flNPCTurnRate[MAX_BOSSES] = { 0.0, ... };
 static float g_flNPCBackstabFOV[MAX_BOSSES] = { 0.0, ... };
 
+static bool g_bNPCTeleportAllowed[MAX_BOSSES][Difficulty_Max];
 static float g_flNPCTeleportTimeMin[MAX_BOSSES][Difficulty_Max];
 static float g_flNPCTeleportTimeMax[MAX_BOSSES][Difficulty_Max];
 static float g_flNPCTeleportRestPeriod[MAX_BOSSES][Difficulty_Max];
@@ -1166,6 +1167,11 @@ float NPCGetAddAcceleration(int iNPCIndex)
 	return g_flNPCAddAcceleration[iNPCIndex];
 }
 
+bool NPCIsTeleportAllowed(int iNPCIndex, int iDifficulty)
+{
+	return g_bNPCTeleportAllowed[iNPCIndex][iDifficulty];
+}
+
 float NPCGetTeleportTimeMin(int iNPCIndex, int iDifficulty)
 {
 	return g_flNPCTeleportTimeMin[iNPCIndex][iDifficulty];
@@ -1706,6 +1712,7 @@ bool SelectProfile(SF2NPC_BaseNPC Npc, const char[] sProfile,int iAdditionalBoss
 		g_flNPCHearingRadius[Npc.Index][iDifficulty] = GetBossProfileHearRadius(iProfileIndex, iDifficulty);
 		g_flSlenderTeleportMinRange[Npc.Index][iDifficulty] = GetBossProfileTeleportRangeMin(iProfileIndex, iDifficulty);
 		g_flSlenderTeleportMaxRange[Npc.Index][iDifficulty] = GetBossProfileTeleportRangeMax(iProfileIndex, iDifficulty);
+		g_bNPCTeleportAllowed[Npc.Index][iDifficulty] = GetBossProfileTeleportAllowed(iProfileIndex, iDifficulty);
 		g_flNPCTeleportTimeMin[Npc.Index][iDifficulty] = GetBossProfileTeleportTimeMin(iProfileIndex, iDifficulty);
 		g_flNPCTeleportTimeMax[Npc.Index][iDifficulty] = GetBossProfileTeleportTimeMax(iProfileIndex, iDifficulty);
 		g_flNPCTeleportRestPeriod[Npc.Index][iDifficulty] = GetBossProfileTeleportTargetRestPeriod(iProfileIndex, iDifficulty);
@@ -4145,13 +4152,17 @@ public Action Timer_SlenderTeleportThink(Handle timer, any iBossIndex)
 	if (SF_IsRenevantMap() && GetRoundState() != SF2RoundState_Escape) return Plugin_Continue;
 
 	if (NPCGetFlags(iBossIndex) & SFF_NOTELEPORT) return Plugin_Continue;
-	
+
+	int iDifficulty = GetLocalGlobalDifficulty(iBossIndex);
+
+	if (!NPCIsTeleportAllowed(iBossIndex, iDifficulty)) return Plugin_Continue;
+
 	// Check to see if anyone's looking at me before doing anything.
 	if (PeopleCanSeeSlender(iBossIndex, _, false))
 	{
 		return Plugin_Continue;
 	}
-	int iDifficulty = GetLocalGlobalDifficulty(iBossIndex);
+	
 	if (NPCGetTeleportType(iBossIndex) == 2)
 	{
 		int iBoss = NPCGetEntIndex(iBossIndex);

--- a/addons/sourcemod/scripting/sf2/profiles/profiles_boss_functions.sp
+++ b/addons/sourcemod/scripting/sf2/profiles/profiles_boss_functions.sp
@@ -315,6 +315,13 @@ enum
 	BossProfileData_StaticGraceTimeNightmare,
 	BossProfileData_StaticGraceTimeApollyon,
 
+	BossProfileData_TeleportAllowedEasy,
+	BossProfileData_TeleportAllowedNormal,
+	BossProfileData_TeleportAllowedHard,
+	BossProfileData_TeleportAllowedInsane,
+	BossProfileData_TeleportAllowedNightmare,
+	BossProfileData_TeleportAllowedApollyon,
+
 	BossProfileData_TeleportRangeMinEasy,
 	BossProfileData_TeleportRangeMinNormal,
 	BossProfileData_TeleportRangeMinHard,
@@ -792,6 +799,13 @@ public bool LoadBossProfile(KeyValues kv, const char[] sProfile, char[] sLoadFai
 	float flBossSearchSoundRadiusInsane = kv.GetFloat("search_sound_range_insane", flBossSearchSoundRadiusHard);
 	float flBossSearchSoundRadiusNightmare = kv.GetFloat("search_sound_range_nightmare", flBossSearchSoundRadiusInsane);
 	float flBossSearchSoundRadiusApollyon = kv.GetFloat("search_sound_range_apollyon", flBossSearchSoundRadiusNightmare);
+
+	bool bBossTeleportAllowed = kv.GetNum("teleport_allowed", 1) != 0;
+	bool bBossTeleportAllowedEasy = kv.GetNum("teleport_allowed_easy", bBossTeleportAllowed) != 0;
+	bool bBossTeleportAllowedHard = kv.GetNum("teleport_allowed_hard", bBossTeleportAllowed) != 0;
+	bool bBossTeleportAllowedInsane = kv.GetNum("teleport_allowed_insane", bBossTeleportAllowedHard) != 0;
+	bool bBossTeleportAllowedNightmare = kv.GetNum("teleport_allowed_nightmare", bBossTeleportAllowedInsane) != 0;
+	bool bBossTeleportAllowedApollyon = kv.GetNum("teleport_allowed_apollyon", bBossTeleportAllowedNightmare) != 0;
 
 	float flBossTeleportRangeMin = kv.GetFloat("teleport_range_min", 325.0);
 	float flBossTeleportRangeMinEasy = kv.GetFloat("teleport_range_min_easy", flBossTeleportRangeMin);
@@ -1328,6 +1342,13 @@ public bool LoadBossProfile(KeyValues kv, const char[] sProfile, char[] sLoadFai
 	g_hBossProfileData.Set(iIndex, flStaticGraceTimeInsane, BossProfileData_StaticGraceTimeInsane);
 	g_hBossProfileData.Set(iIndex, flStaticGraceTimeNightmare, BossProfileData_StaticGraceTimeNightmare);
 	g_hBossProfileData.Set(iIndex, flStaticGraceTimeApollyon, BossProfileData_StaticGraceTimeApollyon);
+
+	g_hBossProfileData.Set(iIndex, bBossTeleportAllowed, BossProfileData_TeleportAllowedNormal);
+	g_hBossProfileData.Set(iIndex, bBossTeleportAllowedEasy, BossProfileData_TeleportAllowedEasy);
+	g_hBossProfileData.Set(iIndex, bBossTeleportAllowedHard, BossProfileData_TeleportAllowedHard);
+	g_hBossProfileData.Set(iIndex, bBossTeleportAllowedInsane, BossProfileData_TeleportAllowedInsane);
+	g_hBossProfileData.Set(iIndex, bBossTeleportAllowedNightmare, BossProfileData_TeleportAllowedNightmare);
+	g_hBossProfileData.Set(iIndex, bBossTeleportAllowedApollyon, BossProfileData_TeleportAllowedApollyon);
 
 	g_hBossProfileData.Set(iIndex, flBossTeleportTimeMin, BossProfileData_TeleportTimeMinNormal);
 	g_hBossProfileData.Set(iIndex, flBossTeleportTimeMinEasy, BossProfileData_TeleportTimeMinEasy);
@@ -2214,6 +2235,20 @@ float GetBossProfileHearRadius(int iProfileIndex, int iDifficulty)
 	}
 	
 	return view_as<float>(g_hBossProfileData.Get(iProfileIndex, BossProfileData_SearchSoundRange));
+}
+
+bool GetBossProfileTeleportAllowed(int iProfileIndex, int iDifficulty)
+{
+	switch (iDifficulty)
+	{
+		case Difficulty_Easy: return view_as<bool>(g_hBossProfileData.Get(iProfileIndex, BossProfileData_TeleportAllowedEasy));
+		case Difficulty_Hard: return view_as<bool>(g_hBossProfileData.Get(iProfileIndex, BossProfileData_TeleportAllowedHard));
+		case Difficulty_Insane: return view_as<bool>(g_hBossProfileData.Get(iProfileIndex, BossProfileData_TeleportAllowedInsane));
+		case Difficulty_Nightmare: return view_as<bool>(g_hBossProfileData.Get(iProfileIndex, BossProfileData_TeleportAllowedNightmare));
+		case Difficulty_Apollyon: return view_as<bool>(g_hBossProfileData.Get(iProfileIndex, BossProfileData_TeleportAllowedApollyon));
+	}
+	
+	return view_as<bool>(g_hBossProfileData.Get(iProfileIndex, BossProfileData_TeleportAllowedNormal));
 }
 
 float GetBossProfileTeleportTimeMin(int iProfileIndex, int iDifficulty)


### PR DESCRIPTION
Some profiles are configured to prevent spawning in certain difficulties in a hacky manner, like so:
```
    "teleport_time_min" "9999.0"
    "teleport_time_min_hard" "6.0"
    "teleport_time_min_insane" "5.0"

    ...

    "teleport_range_min" "9999.9"
    "teleport_range_min_hard" "600.0"

    "teleport_range_max" "9999.9"
    "teleport_range_max_hard" "1500.0"
```

This PR introduces a cleaner implementation of the approach via the `teleport_allowed` keyvalue, which disables boss teleporting on certain difficulties. The default value of `teleport_allowed` is 1, and supports difficulty suffixes.