### PR TITLE
Add PauseTimer and ResumeTimer inputs to sf2_gamerules

### DIFF
--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -735,6 +735,7 @@ bool g_bIsSlaughterRunMap = false;
 bool g_bRoundInfiniteBlink = false;
 bool g_bRoundInfiniteSprint = false;
 
+static bool g_bRoundTimerPaused = false;
 Handle g_hRoundGraceTimer = null;
 static Handle g_hRoundTimer = null;
 static Handle g_hVoteTimer = null;
@@ -3891,6 +3892,11 @@ SF2RoundState GetRoundState()
 	return g_iRoundState;
 }
 
+void SetRoundTimerPaused(bool bPaused)
+{
+	g_bRoundTimerPaused = bPaused;
+}
+
 void SetRoundTime(int iCurrentTime)
 {
 	int iOldRoundTime = g_iRoundTime;
@@ -5595,6 +5601,7 @@ public Action Event_RoundStart(Handle event, const char[] name, bool dB)
 	// Reset some global variables.
 	g_iRoundCount++;
 	g_hRoundTimer = null;
+	g_bRoundTimerPaused = false;
 	
 	SetRoundState(SF2RoundState_Invalid);
 	
@@ -8123,7 +8130,10 @@ public Action Timer_RoundTime(Handle timer)
 	if (g_bSpecialRound)
 		g_iSpecialRoundTime++;
 	
-	SetRoundTime(g_iRoundTime - 1);
+	if (!g_bRoundTimerPaused)
+	{
+		SetRoundTime(g_iRoundTime - 1);
+	}
 	
 	if (SF_SpecialRound(SPECIALROUND_REALISM))
 	{
@@ -8268,7 +8278,10 @@ public Action Timer_RoundTimeEscape(Handle timer)
 	if (g_bSpecialRound)
 		g_iSpecialRoundTime++;
 	
-	SetRoundTime(g_iRoundTime - 1);
+	if (!g_bRoundTimerPaused)
+	{
+		SetRoundTime(g_iRoundTime - 1);
+	}
 	
 	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/sf2/mapentities/sf2_gamerules.sp
+++ b/addons/sourcemod/scripting/sf2/mapentities/sf2_gamerules.sp
@@ -301,6 +301,8 @@ static void Initialize()
 		.DefineInputFunc("ClearBossOverride", InputFuncValueType_Void, InputClearBossOverride)
 		.DefineInputFunc("SetDifficulty", InputFuncValueType_Integer, InputSetDifficulty)
 		.DefineInputFunc("EndGracePeriod", InputFuncValueType_Void, InputEndGracePeriod)
+		.DefineInputFunc("PauseTimer", InputFuncValueType_Void, InputPauseTimer)
+		.DefineInputFunc("ResumeTimer", InputFuncValueType_Void, InputResumeTimer)
 		.DefineOutput("OnGracePeriodEnded")
 		.DefineOutput("OnDifficultyChanged")
 		.DefineOutput("OnStateEnterWaiting")
@@ -637,4 +639,14 @@ static void InputEndGracePeriod(int entity, int activator, int caller)
 {
 	if (GetRoundState() == SF2RoundState_Grace && g_hRoundGraceTimer != null) 
 		TriggerTimer(g_hRoundGraceTimer);
+}
+
+static void InputPauseTimer(int entity, int activator, int caller)
+{
+	SetRoundTimerPaused(true);
+}
+
+static void InputResumeTimer(int entity, int activator, int caller)
+{
+	SetRoundTimerPaused(false);
 }

--- a/sf2.fgd
+++ b/sf2.fgd
@@ -132,6 +132,8 @@
 	input EnableBossesChaseEndlessly(void) : "(Modified only) Enable bosses chasing players endlessly."
 	input DisableBossesChaseEndlessly(void) : "(Modified only) Disable bosses chasing players endlessly."
 	input EndGracePeriod(void) : "Ends the grace period of the round. This will fire the OnGracePeriodEnded output."
+	input PauseTimer(void) : "Pauses the timer."
+	input ResumeTimer(void) : "Resumes the timer."
 
 	output OnStateEnterWaiting(void) : "Sent when entering the Waiting round state."
 	output OnStateExitWaiting(void) : "Sent when exiting the Waiting round state."


### PR DESCRIPTION
Gives maps the ability to pause/resume the round timer via the `PauseTimer` and `ResumeTimer` inputs on the sf2_gamerules entity. The round timer is always unpaused upon round start.