### PR TITLE
Fix AFK for Newly Joined Players

### DIFF
--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -4435,6 +4435,8 @@ public void OnClientPutInServer(int client)
 	ClientSetScareBoostEndTime(client, -1.0);
 
 	ClientStartProxyAvailableTimer(client);
+	
+	AFK_SetTime(client);
 
 	for (int npcIndex = 0; npcIndex < MAX_BOSSES; npcIndex++)
 	{

--- a/addons/sourcemod/scripting/sf2/extras/afk_mode.sp
+++ b/addons/sourcemod/scripting/sf2/extras/afk_mode.sp
@@ -28,6 +28,12 @@ void AFK_SetTime(int client, bool bReset = true)
 	}
 }
 
+void AFK_SetAFK(int client)
+{
+	g_PlayerNoPoints[client] = true;
+	g_AfkAtGameTime[client] = 1.0;
+}
+
 void AFK_CheckTime(int client)
 {
 	if (g_AfkAtGameTime[client] != 0.0 && g_AfkAtGameTime[client] < GetGameTime())

--- a/addons/sourcemod/scripting/sf2/extras/game_events.sp
+++ b/addons/sourcemod/scripting/sf2/extras/game_events.sp
@@ -336,7 +336,6 @@ public Action Event_PlayerTeam(Handle event, const char[] name, bool dB)
 
 			if (!g_FullyEnableSpectatorConVar.BoolValue)
 			{
-				AFK_SetAFK(client);
 				g_PlayerSwitchBlueTimer[client] = CreateTimer(0.5, Timer_PlayerSwitchToBlue, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
 			}
 		}
@@ -344,6 +343,7 @@ public Action Event_PlayerTeam(Handle event, const char[] name, bool dB)
 		{
 			if (!g_PlayerChoseTeam[client])
 			{
+				AFK_SetAFK(client);
 				g_PlayerChoseTeam[client] = true;
 
 				if (g_PlayerPreferences[client].PlayerPreference_ProjectedFlashlight)

--- a/addons/sourcemod/scripting/sf2/extras/game_events.sp
+++ b/addons/sourcemod/scripting/sf2/extras/game_events.sp
@@ -336,6 +336,7 @@ public Action Event_PlayerTeam(Handle event, const char[] name, bool dB)
 
 			if (!g_FullyEnableSpectatorConVar.BoolValue)
 			{
+				AFK_SetAFK(client);
 				g_PlayerSwitchBlueTimer[client] = CreateTimer(0.5, Timer_PlayerSwitchToBlue, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
 			}
 		}


### PR DESCRIPTION
Fixes where AFK status is not set if a player joins the server without inputting any buttons or when being forced to join a team.