### PR TITLE
No Grace Period Page Collecting

### DIFF
--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -910,6 +910,7 @@ ConVar g_UsePlayersForKillFeedConVar;
 ConVar g_DefaultLegacyHudConVar;
 ConVar g_DifficultyVoteOptionsConVar;
 ConVar g_DifficultyVoteRandomConVar;
+ConVar g_DifficultyNoGracePageConVar;
 
 ConVar g_RestartSessionConVar;
 bool g_RestartSessionEnabled;
@@ -3511,6 +3512,22 @@ static Action Hook_PageOnTakeDamage(int page, int &attacker, int &inflictor, flo
 
 void CollectPage(int page, int activator)
 {
+	if (g_RoundState == SF2RoundState_Grace)
+	{
+		char noGracePage[PLATFORM_MAX_PATH];
+		g_DifficultyNoGracePageConVar.GetString(noGracePage, sizeof(noGracePage));
+		if (noGracePage[0])
+		{
+			char match[4];
+			IntToString(g_DifficultyConVar.IntValue, match, sizeof(match));
+			if (StrContains(noGracePage, match) != -1)
+			{
+				CPrintToChat(activator, "{royalblue}%t {default}%t", "SF2 Prefix", "SF2 Grace Period Page");
+				return;
+			}
+		}
+	}
+
 	if (SF_SpecialRound(SPECIALROUND_ESCAPETICKETS))
 	{
 		ClientEscape(activator);

--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -217,6 +217,8 @@ public void OnPluginStart()
 	g_DifficultyVoteOptionsConVar = CreateConVar("sf2_difficulty_vote_options", "1,2,3", "What vote options will appear on the Difficulty vote. 1 = Normal, 2 = Hard, 3 = Insane, 4 = Nightmare, 5 = Apollyon, 6 = Random");
 	g_DifficultyVoteRandomConVar = CreateConVar("sf2_difficulty_random_vote", "1", "If random vote will use a random vote option instead of a random difficulty.", _, true, 0.0, true, 1.0);
 
+	g_DifficultyNoGracePageConVar = CreateConVar("sf2_difficulty_no_grace_pages", "", "On what difficulties will players be unable to collect pages while grace period is active. 1 = Normal, 2 = Hard, 3 = Insane, 4 = Nightmare, 5 = Apollyon");
+
 	g_MaxRoundsConVar = FindConVar("mp_maxrounds");
 
 	g_HudSync = CreateHudSynchronizer();

--- a/addons/sourcemod/translations/sf2.phrases.txt
+++ b/addons/sourcemod/translations/sf2.phrases.txt
@@ -120,6 +120,11 @@
 
 	}
 
+	"SF2 Grace Period Page"
+	{
+		"en"	"Wait for Grace period to end to collect a page."
+	}
+
 	"SF2 Player Escaped"
 	{
 		"#format"		"{1:s}"


### PR DESCRIPTION
Requested by @fearts, adds a cvar `sf2_difficulty_no_grace_pages` that defines on what difficulties players can't collect pages while grace period is active to help spread players out more for the duration of grace period.