### PR TITLE
Fix Native_SetClientFlashlightBatteryLife mistake

### DIFF
--- a/addons/sourcemod/scripting/sf2/methodmaps.sp
+++ b/addons/sourcemod/scripting/sf2/methodmaps.sp
@@ -2166,7 +2166,7 @@ static any Native_SetClientFlashlightBatteryLife(Handle plugin, int numParams)
 	}
 
 	SF2_BasePlayer player = SF2_BasePlayer(client);
-	player.FlashlightBatteryLife = GetNativeCell(3);
+	player.FlashlightBatteryLife = GetNativeCell(2);
 	return 0;
 }
 


### PR DESCRIPTION
Fixes `Invalid parameter number: 3` error when using `SF2_SetClientFlashlightBatteryLife` or `SF2_Player.FlashlightBatteryLife` (1.8.0).