### PR TITLE
Fix AFK Not Applying For Newly Connected

### DIFF
--- a/addons/sourcemod/scripting/sf2.sp
+++ b/addons/sourcemod/scripting/sf2.sp
@@ -3733,6 +3733,8 @@ public void OnClientPutInServer(int client)
 		QueryClientConVar(client, "fov_desired", OnClientGetDesiredFOV);
 	}
 
+	AFK_SetTime(client);
+
 	Call_StartForward(g_OnPlayerPutInServerPFwd);
 	Call_PushCell(SF2_BasePlayer(client));
 	Call_Finish();


### PR DESCRIPTION
OnPlayerRunCmd was updated with IsValidClient which breaks AFK status for newly connected players.