### PR TITLE
Deathcam Fix

### DIFF
--- a/addons/sourcemod/scripting/sf2/npc/entities/base/actions/deathcam.sp
+++ b/addons/sourcemod/scripting/sf2/npc/entities/base/actions/deathcam.sp
@@ -35,6 +35,10 @@ static NextBotAction InitialContainedAction(SF2_DeathCamAction action, SF2_BaseB
 	int sequence = actor.SelectProfileAnimation(g_SlenderAnimationsList[SF2BossAnimation_DeathCam], rate, duration, cycle);
 	if (sequence != -1)
 	{
+		if (SF2_ChaserEntity(actor.index).IsValid())
+		{
+			SF2_ChaserEntity(actor.index).GroundSpeedOverride = true;
+		}
 		return SF2_PlaySequenceAndWait(sequence, duration, rate, cycle);
 	}
 
@@ -59,6 +63,11 @@ static int Update(SF2_DeathCamAction action, SF2_BaseBoss actor, NextBotAction p
 
 static void OnEnd(SF2_DeathCamAction action, SF2_BaseBoss actor)
 {
+	if (SF2_ChaserEntity(actor.index).IsValid())
+	{
+		SF2_ChaserEntity(actor.index).GroundSpeedOverride = false;
+	}
+
 	actor.IsKillingSomeone = false;
 }
 

--- a/addons/sourcemod/scripting/sf2/npc/entities/base/actions/playsequenceandwait.sp
+++ b/addons/sourcemod/scripting/sf2/npc/entities/base/actions/playsequenceandwait.sp
@@ -119,10 +119,6 @@ static int OnStart(SF2_PlaySequenceAndWait action, SF2_BaseBoss actor, NextBotAc
 		duration = actor.SequenceDuration(action.Sequence) / action.Rate;
 		duration *= (1.0 - action.Cycle);
 	}
-	if (SF2_ChaserEntity(actor.index).IsValid())
-	{
-		SF2_ChaserEntity(actor.index).GroundSpeedOverride = true;
-	}
 	action.EndTime = GetGameTime() + duration;
 
 	return action.Continue();
@@ -132,10 +128,6 @@ static int Update(SF2_PlaySequenceAndWait action, SF2_BaseBoss actor, float inte
 {
 	if (GetGameTime() > action.EndTime)
 	{
-		if (SF2_ChaserEntity(actor.index).IsValid())
-		{
-			SF2_ChaserEntity(actor.index).GroundSpeedOverride = false;
-		}
 		return action.Done();
 	}
 
@@ -144,10 +136,6 @@ static int Update(SF2_PlaySequenceAndWait action, SF2_BaseBoss actor, float inte
 
 static int OnSuspend(SF2_PlaySequenceAndWait action, SF2_BaseBoss actor, NextBotAction interruptingAction)
 {
-	if (SF2_ChaserEntity(actor.index).IsValid())
-	{
-		SF2_ChaserEntity(actor.index).GroundSpeedOverride = false;
-	}
 	return action.Done();
 }
 


### PR DESCRIPTION
Moving SF2_ChaserEntity(actor.index).GroundSpeedOverride lines out of the playsequenceandwait script and into to deathcam script. This should make it depend more on the state of the deathcam action itself instead of the state of its sequence/animation.