### PR TITLE
Reimplement static_shake

### DIFF
--- a/addons/sourcemod/scripting/include/sf2.inc
+++ b/addons/sourcemod/scripting/include/sf2.inc
@@ -355,6 +355,7 @@ enum RenevantWave
 #define SFF_ATTACKPROPS (1 << 14)
 #define SFF_WEAPONKILLS (1 << 15)
 #define SFF_WEAPONKILLSONRADIUS (1 << 16)
+#define SFF_HASSTATICSHAKE (1 << 17)
 
 // Interrup conditions.
 #define COND_HEARDSUSPICIOUSSOUND (1 << 0)

--- a/addons/sourcemod/scripting/sf2/client/static.sp
+++ b/addons/sourcemod/scripting/sf2/client/static.sp
@@ -153,6 +153,34 @@ void ClientProcessStaticShake(int client)
 		newPunchAng[i] = oldPunchAng[i];
 		newPunchAngVel[i] = oldPunchAngVel[i];
 	}
+	
+	int staticMaster = NPCGetFromUniqueID(g_PlayerStaticMaster[client]);
+	if (staticMaster != -1 && NPCGetFlags(staticMaster) & SFF_HASSTATICSHAKE)
+	{
+		if (g_PlayerStaticMode[client][staticMaster] == Static_Increase)
+		{
+			newStaticShakeMaster = staticMaster;
+		}
+	}
+	for (int i = 0; i < MAX_BOSSES; i++)
+	{
+		if (NPCGetUniqueID(i) == -1)
+		{
+			continue;
+		}
+
+
+		if (NPCGetFlags(i) & SFF_HASSTATICSHAKE)
+		{
+			int master = NPCGetFromUniqueID(g_SlenderCopyMaster[i]);
+			if (master == -1)
+			{
+				master = i;
+			}
+
+
+		}
+	}
 
 	if (newStaticShakeMaster != -1)
 	{
@@ -267,9 +295,9 @@ void ClientProcessStaticShake(int client)
 		NormalizeVector(newPunchAng, newPunchAng);
 
 		float angVelocityScalar = 5.0 * g_PlayerStaticAmount[client];
-		if (angVelocityScalar < 1.0)
+		if (angVelocityScalar < 0.0)
 		{
-			angVelocityScalar = 1.0;
+			angVelocityScalar = 0.0;
 		}
 		ScaleVector(newPunchAng, angVelocityScalar);
 

--- a/addons/sourcemod/scripting/sf2/profiles/profiles_boss_functions.sp
+++ b/addons/sourcemod/scripting/sf2/profiles/profiles_boss_functions.sp
@@ -567,6 +567,10 @@ bool LoadBossProfile(KeyValues kv, const char[] profile, char[] loadFailReasonBu
 	{
 		bossFlags |= SFF_WEAPONKILLSONRADIUS;
 	}
+	if (kv.GetNum("static_shake"), 0)
+	{
+		bossFlags |= SFF_HASSTATICSHAKE;
+	}
 	profileData.Flags = bossFlags;
 
 	profileData.CopiesInfo.Load(kv);


### PR DESCRIPTION
This reimplements the missing static_shake boss function from the Pre-Modified (Original/New) Versions of Slender Fortress.