### PR TITLE
fix static shake implementation

### DIFF
--- a/addons/sourcemod/scripting/sf2/profiles/profiles_boss_functions.sp
+++ b/addons/sourcemod/scripting/sf2/profiles/profiles_boss_functions.sp
@@ -567,7 +567,7 @@ bool LoadBossProfile(KeyValues kv, const char[] profile, char[] loadFailReasonBu
 	{
 		bossFlags |= SFF_WEAPONKILLSONRADIUS;
 	}
-	if (kv.GetNum("static_shake"), 0)
+	if (kv.GetNum("static_shake", 0))
 	{
 		bossFlags |= SFF_HASSTATICSHAKE;
 	}

--- a/addons/sourcemod/scripting/sf2/profiles/profiles_boss_functions.sp
+++ b/addons/sourcemod/scripting/sf2/profiles/profiles_boss_functions.sp
@@ -567,7 +567,7 @@ bool LoadBossProfile(KeyValues kv, const char[] profile, char[] loadFailReasonBu
 	{
 		bossFlags |= SFF_WEAPONKILLSONRADIUS;
 	}
-	if (kv.GetNum("static_shake", 0))
+	if (kv.GetNum("static_shake"))
 	{
 		bossFlags |= SFF_HASSTATICSHAKE;
 	}


### PR DESCRIPTION
fixes a stupid typo that broke the static shake. this took so long to track down since it was easy to miss and it didn't produce any errors.